### PR TITLE
Set EOSSHIP environment variable

### DIFF
--- a/fairship.sh
+++ b/fairship.sh
@@ -45,6 +45,7 @@ incremental_recipe: |
   # Our environment
   setenv FAIRSHIP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
   setenv FAIRSHIP \$::env(FAIRSHIP_ROOT)
+  setenv EOSSHIP "root://eoslhcb.cern.ch/"
   setenv FAIRSHIP_HASH $FAIRSHIP_HASH
   setenv VMCWORKDIR \$::env(FAIRSHIP)
   setenv GEOMPATH \$::env(FAIRSHIP)/geometry
@@ -147,6 +148,7 @@ module load BASE/1.0                                                            
 # Our environment
 setenv FAIRSHIP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv FAIRSHIP \$::env(FAIRSHIP_ROOT)
+setenv EOSSHIP "root://eoslhcb.cern.ch/"
 setenv FAIRSHIP_HASH $FAIRSHIP_HASH
 setenv VMCWORKDIR \$::env(FAIRSHIP)
 setenv GEOMPATH \$::env(FAIRSHIP)/geometry


### PR DESCRIPTION
When using alibuild currently `EOSSHIP` is not set. This commit corrects
this by adding it to the module file.