### PR TITLE
MadGraph5 first implementation

### DIFF
--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -173,6 +173,9 @@ overrides:
     version: "%(tag_basename)s"
     source: https://github.com/ShipSoft/geant3
     tag: v3.2.1-ship
+  madgraph5:
+    version: "%(tag_basename)s"
+    tag: v2.6.1-ship
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/fairship.sh
+++ b/fairship.sh
@@ -13,6 +13,7 @@ requires:
   - ROOT
 build_requires:
   - googletest
+  - madgraph5
 incremental_recipe: |
   rsync -ar $SOURCEDIR/ $INSTALLROOT/
   make ${JOBS:+-j$JOBS}
@@ -43,7 +44,8 @@ incremental_recipe: |
             ${GENIE_VERSION:+GENIE/$GENIE_VERSION-$GENIE_REVISION}              \\
             ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}  \\
             ${EVTGEN_VERSION:+EvtGen/$EVTGEN_VERSION-$EVTGEN_REVISION}          \\
-            FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION                       
+            FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION			\\
+            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION}
   # Our environment
   setenv EOSSHIP root://eospublic.cern.ch/
   setenv FAIRSHIP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
@@ -152,7 +154,8 @@ module load BASE/1.0                                                            
             ${GENIE_VERSION:+GENIE/$GENIE_VERSION-$GENIE_REVISION}              \\
             ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}  \\
             ${EVTGEN_VERSION:+EvtGen/$EVTGEN_VERSION-$EVTGEN_REVISION}          \\
-            FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION                       
+            FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION                       \\
+            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION}
 # Our environment
 setenv EOSSHIP root://eospublic.cern.ch/
 setenv FAIRSHIP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version

--- a/fairship.sh
+++ b/fairship.sh
@@ -11,9 +11,9 @@ requires:
   - PHOTOSPP
   - EvtGen
   - ROOT
+  - madgraph5
 build_requires:
   - googletest
-  - madgraph5
 incremental_recipe: |
   rsync -ar $SOURCEDIR/ $INSTALLROOT/
   make ${JOBS:+-j$JOBS}

--- a/madgraph5.sh
+++ b/madgraph5.sh
@@ -1,0 +1,38 @@
+package: madgraph5
+version: "%(tag_basename)s%(defaults_upper)s"
+source: https://github.com/shir994/madgraph5
+requires:
+  - GCC-Toolchain
+  - pythia
+tag: master
+
+---
+#!/bin/bash -e
+
+wget https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.1.tar.gz
+tar -xf MG5_aMC_v2.6.1.tar.gz -C ./ --strip 1
+
+echo "pythia8_path = ${PYTHIA_ROOT}" >> ./input/mg5_configuration.txt
+
+rsync -ar $BUILDDIR/ $INSTALLROOT/
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0                                                   \\
+	    ${PYTHIA_VERSION:+pythia/$PYTHIA_VERSION-$PYTHIA_REVISION} \\
+	    lhapdf5/${LHAPDF5_VERSION}-${LHAPDF5_REVISION}
+# Our environment
+setenv MADGRAPH_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(MADGRAPH_ROOT)/bin
+EoF


### PR DESCRIPTION
Since the problems of transferring from launchpad to Git, for now the script will just download the .tar version of MadGraph5. MadGraph written in python, so seems you do not need to build it. In worst case, it will build some stuff automatically.