### PR TITLE
Use CURL instead of WGET, which might not be installed

### DIFF
--- a/madgraph5.sh
+++ b/madgraph5.sh
@@ -9,7 +9,7 @@ tag: master
 ---
 #!/bin/bash -e
 
-wget https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.1.tar.gz
+curl -O -L https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.1.tar.gz
 tar -xf MG5_aMC_v2.6.1.tar.gz -C ./ --strip 1
 
 echo "pythia8_path = ${PYTHIA_ROOT}" >> ./input/mg5_configuration.txt


### PR DESCRIPTION
Fails in clean machines as wget might not be installed. As curl is installed by aliBuild, we should use it instead. Feature-wise wget and curl are very similar.