### PR TITLE
Update pip to fix build issue on ubuntu 16.04.03

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -44,7 +44,8 @@ export PYVER=$(python -c 'import distutils.sysconfig; print(distutils.sysconfig.
 # Install as much as possible with pip. Packages are installed one by one as we
 # are not sure that pip exits with nonzero in case one of the packages failed.
 export PYTHONUSERBASE=$INSTALLROOT
-for X in "mock==1.0.0"         \
+for X in "pip==9.0.3"          \
+         "mock==1.0.0"         \
          "numpy==1.9.2"        \
          "certifi==2015.9.6.2" \
          "ipython==5.1.0"      \


### PR DESCRIPTION
There was a strange issue with python package dependencies (pip did not find previously installed dependencies and tried to pull in a version that only works with python 3).

There seem to be two solutions:

1. explicitly install the dependency alongside each package requiring it
2. upgrade pip

As pip is only used a build time, upgrading it should be safe and 1. could lead to problems with exit codes and silent build failure.