### PR TITLE
OpenGL requirement on Mac OS X

### DIFF
--- a/opengl.sh
+++ b/opengl.sh
@@ -7,8 +7,8 @@ system_requirement_missing: |
 system_requirement: ".*"
 system_requirement_check: |
   case $ARCHITECTURE in 
-  osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
-  *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
+   osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
+   *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
   esac
 ---
 

--- a/opengl.sh
+++ b/opengl.sh
@@ -6,9 +6,11 @@ system_requirement_missing: |
     * On Ubuntu-compatible systems you probably need: libglu1-mesa-dev
 system_requirement: ".*"
 system_requirement_check: |
-  case $ARCHITECTURE in 
-   osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
-   *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
-  esac
+
+  if [ uname = Darwin ]; then
+   printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null
+  else
+   printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null
+  fi
 ---
 

--- a/opengl.sh
+++ b/opengl.sh
@@ -6,6 +6,9 @@ system_requirement_missing: |
     * On Ubuntu-compatible systems you probably need: libglu1-mesa-dev
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null
+  case $ARCHITECTURE in 
+  osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
+  *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
+  esac
 ---
 


### PR DESCRIPTION
In OS X include folders are different (see https://en.wikibooks.org/wiki/OpenGL_Programming/Installation/Mac), thus leading to the builder assuming you do not have the required package.

This edit should solve the issue.
Waiting for your comments.
Best regards,
Antonio