### PR TITLE
Add support of python for Pythia

### DIFF
--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -173,9 +173,6 @@ overrides:
     version: "%(tag_basename)s"
     source: https://github.com/ShipSoft/geant3
     tag: v3.2.1-ship
-  madgraph5:
-    version: "%(tag_basename)s"
-    tag: v2.6.1-ship
 ---
 # This file is included in any build recipe and it's only used to set
 # environment variables. Which file to actually include can be defined by the

--- a/pythia.sh
+++ b/pythia.sh
@@ -5,6 +5,7 @@ requires:
   - lhapdf
   - HepMC
   - boost
+  - Python
 tag: v8223
 env:
   PYTHIA8DATA: "$PYTHIA_ROOT/share/Pythia8/xmldoc"
@@ -19,9 +20,12 @@ case $ARCHITECTURE in
   ;;
 esac
 
+PYTHON_INCLUDE=`echo "{$(python-config --includes)//-I}" | cut -d ' ' -f 1 | cut -c 4-`
+
 ./configure --prefix=$INSTALLROOT \
             --enable-shared \
             --with-hepmc2=${HEPMC_ROOT} \
+            --with-python-include=${PYTHON_INCLUDE} \
             ${LHAPDF_ROOT:+--with-lhapdf6="$LHAPDF_ROOT"} \
             ${BOOST_ROOT:+--with-boost="$BOOST_ROOT"}
 
@@ -55,5 +59,6 @@ setenv PYTHIA8DATA \$::env(PYTHIA_ROOT)/share/Pythia8/xmldoc
 setenv PYTHIA8 \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(PYTHIA_ROOT)/bin
 prepend-path LD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib
+prepend-path PYTHONPATH \$::env(PYTHIA_ROOT)/lib
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib")
 EoF


### PR DESCRIPTION
Provide flag to build Pythia with python support. If python is not found, should not fail, but build without it.