### PR TITLE
Change version of madgraph5

### DIFF
--- a/madgraph5.sh
+++ b/madgraph5.sh
@@ -9,8 +9,8 @@ tag: master
 ---
 #!/bin/bash -e
 
-curl -O -L https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.1.tar.gz
-tar -xf MG5_aMC_v2.6.1.tar.gz -C ./ --strip 1
+curl -O -L https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.2.tar.gz
+tar -xf MG5_aMC_v2.6.2.tar.gz -C ./ --strip 1
 
 echo "pythia8_path = ${PYTHIA_ROOT}" >> ./input/mg5_configuration.txt
 


### PR DESCRIPTION
Installation fails, after attempting to install madgraph5 ver. 2.6.1
Solution: change version to 2.6.2