### PR TITLE
Necessary changes for Fedora 28

### DIFF
--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -26,7 +26,7 @@ overrides:
       which gfortran || { echo "gfortran missing"; exit 1; }
       which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060000 || GCCVER > 0x090000)\n#error \"System's GCC cannot be used: we need GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   XRootD:
-    tag: v4.6.1
+    tag: v4.8.3
   ROOT:
     version: "%(tag_basename)s"
     tag: "v6-13-02-ship"

--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -24,7 +24,7 @@ overrides:
     prefer_system_check: |
       set -e
       which gfortran || { echo "gfortran missing"; exit 1; }
-      which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060000 || GCCVER > 0x080000)\n#error \"System's GCC cannot be used: we need GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
+      which cc && test -f $(dirname $(which cc))/c++ && printf "#define GCCVER ((__GNUC__ << 16)+(__GNUC_MINOR__ << 8)+(__GNUC_PATCHLEVEL__))\n#if (GCCVER < 0x060000 || GCCVER > 0x090000)\n#error \"System's GCC cannot be used: we need GCC 6.X. We are going to compile our own version.\"\n#endif\n" | cc -xc++ - -c -o /dev/null
   XRootD:
     tag: v4.6.1
   ROOT:

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -11,6 +11,8 @@ requires:
 
 rsync -a --exclude '**/.git' $SOURCEDIR/ ./
 
+export FFLAGS=--std=legacy
+
 ./configure --prefix=$INSTALLROOT
 
 make ${JOBS+-j $JOBS} all


### PR DESCRIPTION
This pull request collects any changes necessary to build FairShip with Fedora 28. Most changes are due to the new GCC version included (8.0.1).

Currently the build is in progress, with ROOT currently being built. Once the full build completes successfully this is ready to be merged.

I plan to look at Ubuntu 18.04 next, if I have the time.