### PR TITLE
Fix commented lilne ending escape

### DIFF
--- a/pythia.sh
+++ b/pythia.sh
@@ -23,8 +23,8 @@ esac
             --enable-shared \
             --with-hepmc2=${HEPMC_ROOT} \
             --with-lhapdf5-lib=${LHAPDF5_ROOT}/lib --with-lhapdf5-include=${LHAPDF5_ROOT}/include  \
-           # ${LHAPDF_ROOT:+--with-lhapdf6="$LHAPDF_ROOT"} \
             ${BOOST_ROOT:+--with-boost="$BOOST_ROOT"}
+           # ${LHAPDF_ROOT:+--with-lhapdf6="$LHAPDF_ROOT"}
 
 if [[ $ARCHITECTURE =~ "slc5.*" ]]; then
     ln -s LHAPDF5.h include/Pythia8Plugins/LHAPDF5.cc


### PR DESCRIPTION
The previous change to pythia.sh breaks the pythia build, as the commented escape of the line ending is not seen. This causes bash to interpret the `--with-boost` argument as a new command. The fix is trivial.