### PR TITLE
Add scikit-learn

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -12,7 +12,7 @@ prepend_path:
   PYTHONPATH: $PYTHON_MODULES_ROOT/lib/python2.7/site-packages:$PYTHONPATH
 prefer_system: (?!slc5)
 prefer_system_check:
-  python -c 'import matplotlib,numpy, scipy, certifi,IPython,ipywidgets,ipykernel,notebook.notebookapp,metakernel,yaml';
+  python -c 'import matplotlib,numpy, scipy, certifi,IPython,ipywidgets,ipykernel,notebook.notebookapp,metakernel,yaml,sklearn';
   if [ $? -ne 0 ]; then printf "Required Python modules are missing. You can install them with pip (better as root):\n  pip install matplotlib numpy certifi ipython ipywidgets ipykernel notebook metakernel pyyaml\n"; exit 1; fi
 ---
 #!/bin/bash -ex
@@ -31,6 +31,7 @@ If you want to avoid this please install the following modules (pip recommended)
   - notebook
   - metakernel
   - pyyaml
+  - scikit-learn
 
 EoF
 fi
@@ -54,6 +55,7 @@ for X in "pip==9.0.3"          \
          "notebook==4.2.3"     \
          "metakernel==0.14.0"  \
          "scipy==0.17.1"        \
+         "scikit-learn==0.19.1" \
          "pyyaml"
 do
   python -m pip install --user $X


### PR DESCRIPTION
After the discussion with Tiziano, this now checks and installs `scikit-learn` for `ShipReco.py` in `shipdist`.