### PR TITLE
Copy GENIE pdf to lhapdf

### DIFF
--- a/genie.sh
+++ b/genie.sh
@@ -52,6 +52,8 @@ rsync -a src/* $INSTALLROOT/genie/src
 mkdir -p $INSTALLROOT/genie/inc
 rsync -a src/*/*.h $INSTALLROOT/genie/inc
 
+cp $INSTALLROOT/genie/data/evgen/pdfs/GRV98lo_patched.LHgrid $LHAPDF5_ROOT/share/lhapdf
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
This way we do not need to do so manually in `aliBuild.sh`.

The file is in the same location as when copied in `aliBuild.sh`, so the end result should be indistinguishable.

Once merged, we can remove the line from `aliBuild.sh`, so that the script only wraps `aliBuild` and does not do anything non-trivial itself.