### PR TITLE
[WiP] Add ControlHost for test beam online monitoring

### DIFF
--- a/controlhost.sh
+++ b/controlhost.sh
@@ -1,0 +1,36 @@
+package: ControlHost
+version: "7cd37ac78e3e5d2974ee592b8db7de255ca2c621"
+source: https://gitlab.cern.ch/olantwin/ControlHost
+build_requires:
+ - "GCC-Toolchain:(?!osx)"
+---
+#!/bin/sh
+set -ex
+cd "$SOURCEDIR"/src || exit -1
+export INSTALL_PATH=$INSTALLROOT
+
+make bin
+make ${JOBS+-j $JOBS}
+LIB=SHARED make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "SHiP Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "SHiP Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+setenv CONTHOST_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path LD_LIBRARY_PATH \$::env(CONTHOST_ROOT)/lib
+prepend-path PATH \$::env(CONTHOST_ROOT)/bin
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(CONTHOST_ROOT)/lib")
+EoF

--- a/fairship.sh
+++ b/fairship.sh
@@ -12,6 +12,7 @@ requires:
   - EvtGen
   - ROOT
   - madgraph5
+  - ControlHost
 build_requires:
   - googletest
 incremental_recipe: |
@@ -45,7 +46,8 @@ incremental_recipe: |
             ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}  \\
             ${EVTGEN_VERSION:+EvtGen/$EVTGEN_VERSION-$EVTGEN_REVISION}          \\
             FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION			\\
-            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION}
+            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION} \\
+            ${CONTROLHOST_VERSION:+ControlHost/$CONTROLHOST_VERSION-$CONTROLHOST_REVISION}
   # Our environment
   setenv EOSSHIP root://eospublic.cern.ch/
   setenv FAIRSHIP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
@@ -155,7 +157,8 @@ module load BASE/1.0                                                            
             ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}  \\
             ${EVTGEN_VERSION:+EvtGen/$EVTGEN_VERSION-$EVTGEN_REVISION}          \\
             FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION                       \\
-            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION}
+            ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION} \\
+            ${CONTROLHOST_VERSION:+ControlHost/$CONTROLHOST_VERSION-$CONTROLHOST_REVISION}
 # Our environment
 setenv EOSSHIP root://eospublic.cern.ch/
 setenv FAIRSHIP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version


### PR DESCRIPTION
This lays the groundwork for using ControlHost in FairShip. As next step I will need to do some modifications to the FairShip recipe and eventually to FairShip to pick up headers and link correctly.

This should not be merged just yet.

Edit: This currently needs to be explicitly built, as nothing depends on it (yet).