### PR TITLE
Fix matplotlib download

### DIFF
--- a/python-modules.sh
+++ b/python-modules.sh
@@ -64,7 +64,7 @@ unset PYTHONUSERBASE
 
 # Install matplotlib (quite tricky)
 MATPLOTLIB_VER="1.4.3"
-MATPLOTLIB_URL="http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-${MATPLOTLIB_VER}/matplotlib-${MATPLOTLIB_VER}.tar.gz"
+MATPLOTLIB_URL="https://github.com/matplotlib/matplotlib/archive/v$MATPLOTLIB_VER.tar.gz"
 curl -Lo matplotlib.tgz $MATPLOTLIB_URL
 tar xzf matplotlib.tgz
 cd matplotlib-$MATPLOTLIB_VER


### PR DESCRIPTION
Sourceforge download does not work anymore, so moving to Github.

We should consider moving to a newer matplotlib: the current version is 3 years old!
As none of our code nor FairRoot use matplotlib currently, and the interface is
pretty stable between versions it should be pretty safe to bump to something
newer (although the build procedure might need to be modified.