### PR TITLE
Do not build madgraph by default

### DIFF
--- a/fairship.sh
+++ b/fairship.sh
@@ -11,7 +11,6 @@ requires:
   - PHOTOSPP
   - EvtGen
   - ROOT
-  - madgraph5
 build_requires:
   - googletest
 incremental_recipe: |


### PR DESCRIPTION
The madgraph build keeps breaking, so to not affect building FairShip (which does not include any code depending on madgraph yet), I suggest we don't build it by default for now.

If someone needs to build it, they can run:
`aliBuild -c shipdist/ --defaults fairship build madgraph` (assuming the build procedure works).

I discussed this with @shir994 as he's the main user of madgraph, and he has no objections.