### PR TITLE
Don't overwrite with old lhapdf5 version

### DIFF
--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -135,13 +135,6 @@ overrides:
     version: "%(tag_basename)s"
     tag: v3-6-ship
     source: https://github.com/ShipSoft/geant4_vmc.git
-  lhapdf5:
-    source: https://github.com/ShipSoft/LHAPDF
-    version: "%(tag_basename)s"
-    tag: v5.9.1-ship1
-    env:
-      LHAPATH: "$LHAPDF_ROOT/share/LHAPDF"
-      GEANT4_INSTALL: "$GEANT4_ROOT"
   GENIE:
     tag: v2.12.6-ship
   pythia:

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -1,9 +1,10 @@
 package: lhapdf5
 tag: v5.9.1-ship2
-version: "%(tag_basename)s%(defaults_upper)s"
+version: "%(tag_basename)s"
 source: https://github.com/ShipSoft/LHAPDF.git
 env:
-  LHAPATH: "$LHAPDF5_ROOT/share/lhapdf"
+  LHAPATH: "$LHAPDF_ROOT/share/LHAPDF"
+  GEANT4_INSTALL: "$GEANT4_ROOT"
 requires:
  - "GCC-Toolchain:(?!osx)"
 ---


### PR DESCRIPTION
The fix to `lhapdf5` works, but the version was overwritten in `defaults-fairship.sh`, where `v5.9.1-ship1` is specified. I remove the duplicate lines and merge the two metadata blocks.