### PR TITLE
Update ROOT version to upstream 6.14/06

### DIFF
--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -31,8 +31,8 @@ overrides:
     tag: v4.8.3
   ROOT:
     version: "%(tag_basename)s"
-    tag: "v6-14-00-ship"
-    source: https://github.com/ShipSoft/root
+    tag: "v6-14-06"
+    source: https://github.com/root-project/root
     requires:
       - GSL
       - opengl:(?!osx)


### PR DESCRIPTION
To be merged once testing is completed.

Works on:
- [x] `slc6`
- [x] `cc7`
- [x] `fedora29`