### PR TITLE
update dependencies recipes to build out of the box in openstack

### DIFF
--- a/libxml2.sh
+++ b/libxml2.sh
@@ -1,11 +1,11 @@
 package: libxml2
-version: v2.9.3
-source: https://git.gnome.org/browse/libxml2
+version: "%(tag_basename)s"
 tag: v2.9.3
 build_requires:
   - autotools
   - zlib
   - "GCC-Toolchain:(?!osx)"
+source: https://gitlab.gnome.org/GNOME/libxml2.git
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   xml2-config --version;
@@ -33,7 +33,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0
+module load BASE/1.0 ${ZLIB_VERSION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}
 # Our environment
 setenv LIBXML2_VERSION \$version
 setenv LIBXML2_ROOT \$::env(BASEDIR)/$PKGNAME/\$::env(LIBXML2_VERSION)

--- a/openssl.sh
+++ b/openssl.sh
@@ -1,10 +1,10 @@
 package: OpenSSL
-version: v0.9.8zf
-tag: "v0.9.8_1.2.4"
-source: https://github.com/alisw/alice-openssl.git
+version: v1.0.2o
+tag: OpenSSL_1_0_2o
+source: https://github.com/openssl/openssl
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
-  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
+  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; echo -e "#include <openssl/opensslv.h>\n#if OPENSSL_VERSION_NUMBER >= 0x10100000L\n#error \"System's GCC cannot be used: we need OpenSSL 1.0.x to build XrootD. We are going to compile our own version.\"\n#endif\nint main() { }" | cc -xc++ - -c -o /dev/null || exit 1
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"
@@ -13,47 +13,47 @@ build_requires:
 
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ .
 
-pushd openssl-fips
-  ./config --openssldir=$INSTALLROOT/fips \
-           fipscanisterbuild \
-           no-asm
-  # Does not build in multicore!
-  make
-  make install
-popd
+./config --prefix="$INSTALLROOT"                   \
+         --openssldir="$INSTALLROOT/etc/ssl"       \
+         --libdir=lib                              \
+         zlib                                      \
+         no-idea                                   \
+         no-mdc2                                   \
+         no-rc5                                    \
+         no-ec                                     \
+         no-ecdh                                   \
+         no-ecdsa                                  \
+         no-asm                                    \
+         no-krb5                                   \
+         shared                                    \
+         -fno-strict-aliasing                      \
+         -L"$INSTALLROOT/lib"                      \
+         -Wa,--noexecstack
+make depend
+make  # don't ever try to build in multicore
+make install
 
-OLD_OPENSSL=TRUE
-if [ "$PKG_VERSION" == "*v1.0*" ]
-then
-    unset OLD_OPENSSL
-    NEW_OPENSSL=TRUE
-fi
+# Remove static libraries and pkgconfig
+rm -rf $INSTALLROOT/lib/pkgconfig \
+       $INSTALLROOT/lib/*.a
 
-pushd openssl
-  ./config --openssldir="$INSTALLROOT" \
-           ${OLD_OPENSSL:+--with-fipslibdir="$INSTALLROOT/fips/lib"}  \
-           ${NEW_OPENSSL:+--with-fipslibdir="$INSTALLROOT/fips/lib/"} \
-           ${NEW_OPENSSL:+--with-fipsdir="$INSTALLROOT/fips"} \
-           fips \
-           zlib \
-           no-idea \
-           no-mdc2 \
-	   ${OLD_OPENSSL:+ no-ec no-ecdh no-ecdsa} \
-           no-rc5 \
-           no-asm \
-           no-krb5 \
-           shared \
-           -fno-strict-aliasing \
-           -L"${INSTALLROOT}/lib" \
-           -Wa,--noexecstack \
-           -DOPENSSL_USE_NEW_FUNCTIONS
-  # Does not build in multicore!
-  ${NEW_OPENSSL:+ make depend}
-  make
-  make install
-popd
-
-rm -rf $INSTALLROOT/pkgconfig \
-       $INSTALLROOT/fips/pkgconfig \
-       $INSTALLROOT/lib/*.a \
-       $INSTALLROOT/fips/lib/*.a
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${ZLIB_VERSION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION} ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+setenv OPENSSL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(OPENSSL_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(OPENSSL_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(OPENSSL_ROOT)/lib")
+EoF

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -45,17 +45,17 @@ export PYVER=$(python -c 'import distutils.sysconfig; print(distutils.sysconfig.
 # Install as much as possible with pip. Packages are installed one by one as we
 # are not sure that pip exits with nonzero in case one of the packages failed.
 export PYTHONUSERBASE=$INSTALLROOT
-for X in "pip==9.0.3"          \
-         "mock==1.0.0"         \
-         "numpy==1.9.2"        \
-         "certifi==2015.9.6.2" \
-         "ipython==5.1.0"      \
-         "ipywidgets==5.2.2"   \
-         "ipykernel==4.5.0"    \
-         "notebook==4.2.3"     \
-         "metakernel==0.14.0"  \
-         "scipy==0.17.1"        \
-         "scikit-learn==0.19.1" \
+for X in "pip==19.1.1"          \
+         "mock==1.3.0"          \
+         "numpy==1.16.4"        \
+         "certifi==2019.6.16"   \
+         "ipython==5.8.0"       \
+         "ipywidgets==5.2.3"    \
+         "ipykernel==4.10.0"    \
+         "notebook==4.4.1"      \
+         "metakernel==0.24.2"   \
+         "scipy==1.3.0"         \
+         "scikit-learn==0.21.1" \
          "pyyaml"
 do
   python -m pip install --user $X
@@ -63,34 +63,44 @@ done
 unset PYTHONUSERBASE
 
 # Install matplotlib (quite tricky)
-MATPLOTLIB_VER="1.4.3"
-MATPLOTLIB_URL="https://github.com/matplotlib/matplotlib/archive/v$MATPLOTLIB_VER.tar.gz"
-curl -Lo matplotlib.tgz $MATPLOTLIB_URL
-tar xzf matplotlib.tgz
-cd matplotlib-$MATPLOTLIB_VER
-cat > setup.cfg <<EOF
+MATPLOTLIB_TAG="3.0.3"
+if [[ $ARCHITECTURE != slc* ]]; then
+  # Simply get it via pip in most cases
+  env PYTHONUSERBASE=$INSTALLROOT pip install --user "matplotlib==$MATPLOTLIB_TAG"
+else
+
+  # We are on a RHEL-compatible OS. We compile it ourselves, and link it to our dependencies
+
+  # Check if we can enable the Tk interface
+  python -c 'import _tkinter' && MATPLOTLIB_TKAGG=True || MATPLOTLIB_TKAGG=False
+  MATPLOTLIB_URL="https://github.com/matplotlib/matplotlib/archive/v${MATPLOTLIB_TAG}.tar.gz"  # note the "v"
+  curl -SsL "$MATPLOTLIB_URL" | tar xzf -
+  cd matplotlib-*
+  cat > setup.cfg <<EOF
 [directories]
 basedirlist  = ${FREETYPE_ROOT:+$PWD/fake_freetype_root,$FREETYPE_ROOT,}${LIBPNG_ROOT:+$LIBPNG_ROOT,}${ZLIB_ROOT:+$ZLIB_ROOT,}/usr/X11R6,$(freetype-config --prefix),$(libpng-config --prefix)
 [gui_support]
 gtk = False
 gtkagg = False
-tkagg = False
+tkagg = $MATPLOTLIB_TKAGG
 wxagg = False
 macosx = False
 EOF
 
-# matplotlib wants include files in <PackageRoot>/include, but this is not the
-# case for FreeType: let's fix it
-if [[ $FREETYPE_ROOT ]]; then
-  mkdir fake_freetype_root
-  ln -nfs $FREETYPE_ROOT/include/freetype2 fake_freetype_root/include
-fi
-perl -p -i -e "s|'darwin': \['/usr/local/'|'darwin': ['$INSTALLROOT'|g" setupext.py
+  # matplotlib wants include files in <PackageRoot>/include, but this is not the case for FreeType
+  if [[ $FREETYPE_ROOT ]]; then
+    mkdir fake_freetype_root
+    ln -nfs $FREETYPE_ROOT/include/freetype2 fake_freetype_root/include
+  fi
 
-mkdir -p $INSTALLROOT/{lib,lib64}/python$PYVER/site-packages
-python setup.py build
-PYTHONPATH=$INSTALLROOT/lib64/python$PYVER/site-packages:$INSTALLROOT/lib/python$PYVER/site-packages:$PYTHONPATH \
-  python setup.py install --prefix $INSTALLROOT
+  export PYTHONPATH="$INSTALLROOT/lib/python/site-packages"
+    python setup.py build
+    python setup.py install --prefix "$INSTALLROOT"
+  unset PYTHONPATH
+fi
+
+# Test if matplotlib can be loaded
+env PYTHONPATH="$INSTALLROOT/lib/python/site-packages" python -c 'import matplotlib'
 
 # Remove unneeded stuff
 rm -rvf $INSTALLROOT/share            \


### PR DESCRIPTION
Hi all,

I was getting familiar with the repository.

The dependencies recipes where a little outdated and it wasn't building from scratch properly.

At the moment this is been tested only on CC7, is possible to test as well on SLC6, for MAC I have more issues with the hardware at the moment.

In the process I also create another docker image (accessible here: https://gitlab.cern.ch/smosciat/shiptest/container_registry) to build FairShip based on alidock.

