### PR TITLE
Fixing syntax

### DIFF
--- a/opengl.sh
+++ b/opengl.sh
@@ -7,8 +7,8 @@ system_requirement_missing: |
 system_requirement: ".*"
 system_requirement_check: |
   case $ARCHITECTURE in 
-  osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
-  *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
+   osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
+   *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
   esac
 ---
 

--- a/opengl.sh
+++ b/opengl.sh
@@ -6,9 +6,11 @@ system_requirement_missing: |
     * On Ubuntu-compatible systems you probably need: libglu1-mesa-dev
 system_requirement: ".*"
 system_requirement_check: |
-  case $ARCHITECTURE in 
-   osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
-   *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
-  esac
+
+  if [ uname = Darwin ]; then
+   printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null
+  else
+   printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null
+  fi
 ---
 

--- a/opengl.sh
+++ b/opengl.sh
@@ -6,6 +6,9 @@ system_requirement_missing: |
     * On Ubuntu-compatible systems you probably need: libglu1-mesa-dev
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null
+  case $ARCHITECTURE in 
+  osx*) printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null;; 
+  *) printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null;;
+  esac
 ---
 

--- a/opengl.sh
+++ b/opengl.sh
@@ -7,7 +7,7 @@ system_requirement_missing: |
 system_requirement: ".*"
 system_requirement_check: |
 
-  if [ uname = Darwin ]; then
+  if [ $(uname) = Darwin ]; then
    printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null
   else
    printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null


### PR DESCRIPTION
Sorry,

after doing some quick tests,

I noticed that the $(command) is required for the BASH equivalence condition to work properly 
(as far as I have noticed, also = and == seem to produce the same result, differently from C++ and Python). Maybe somebody more expert than me in BASH programming can check that this is correct.

Best regards,
Antonio