### PR TITLE
Update repository URL for Xerces-C

### DIFF
--- a/xercesc.sh
+++ b/xercesc.sh
@@ -1,6 +1,6 @@
 package: XercesC
 version: v3.1.4
-source: https://apache.googlesource.com/xerces-c
+source: https://github.com/apache/xerces-c
 tag: Xerces-C_3_1_4
 build_requires:
   - GCC-Toolchain:(?!osx)


### PR DESCRIPTION
As mentioned by Antonio on the mailing list, the old URL has stopped working.