### PR TITLE
Use pkg-config instead of freetype-config

### DIFF
--- a/freetype.sh
+++ b/freetype.sh
@@ -7,7 +7,7 @@ build_requires:
   - curl
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include <ft2build.h>\n" | gcc -xc++ - `freetype-config --cflags` -c -M 2>&1;
+  printf "#include <ft2build.h>\n" | gcc -xc++ - `pkg-config freetype2 --cflags` -c -M 2>&1;
   if [ $? -ne 0 ]; then printf "FreeType is missing on your system.\n * On RHEL-compatible systems you probably need: freetype freetype-devel\n * On Ubuntu-compatible systems you probably need: libfreetype6 libfreetype6-dev\n"; exit 1; fi
 ---
 #!/bin/bash -ex

--- a/xdevel.sh
+++ b/xdevel.sh
@@ -6,6 +6,6 @@ system_requirement_missing: |
    * On Ubuntu-compatible systems you probably need: libxpm-dev libxext-dev libx11-dev libxft-dev
 system_requirement: ".*"
 system_requirement_check: |
-  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `freetype-config --cflags` -c -o /dev/null
+  printf "#include <X11/Xlib.h>\n#include <X11/xpm.h>\n#include <X11/Xft/Xft.h>\n#include <X11/extensions/Xext.h>\n" | cc -xc - -I/opt/X11/include `pkg-config freetype2 --cflags` -c -o /dev/null
 ---
 


### PR DESCRIPTION
`freetype-config` does not exist anymore on e.g. recent Ubuntu.
It has been replaced by `pkg-config` for many years now.
This should work without issue on any distribution since `slc6`.