### PR TITLE
Update python recipe to use pkg-config

### DIFF
--- a/python.sh
+++ b/python.sh
@@ -15,9 +15,12 @@ env:
   SSL_CERT_FILE: "$(export PATH=$PYTHON_ROOT/bin:$PATH; export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH; python -c \"import certifi; print(certifi.where())\")"
   PYTHONHOME: "$PYTHON_ROOT"
   PYTHONPATH: "$PYTHON_ROOT/lib/python/site-packages"
-prefer_system: "(?!slc5)"
-prefer_system_check:
-  python3 -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (3, 5) else 0)' && pip3 --help > /dev/null && printf '#include "pyconfig.h"' | cc -c $(python-config --includes) -xc -o /dev/null -; if [ $? -ne 0 ]; then printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n"; exit 1; fi
+prefer_system: ".*"
+prefer_system_check: |
+  set -e
+  python3 -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (3, 5) else 0)'
+  pip3 --help > /dev/null
+  printf '#include "pyconfig.h"' | cc -c $(pkg-config python3 --cflags) -xc -o /dev/null - || printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n" &&  exit 1
 ---
 #!/bin/bash -ex
 


### PR DESCRIPTION
`python-config` doesn't exist on e.g. Fedora 30. Instead, only python3-config exists.

It appears there are some issues with python(3)-config in general (e.g. https://bugzilla.redhat.com/show_bug.cgi?id=1724190), so using pkg-config instead might give more robust results.

The `prefer_system_check` is also reformatted a bit to be more readable and the reference to the obsolete slc5 is removed.