### PR TITLE
Update ROOT, use CMAKE_CXX_STANDARD

### DIFF
--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -4,6 +4,7 @@ env:
   CXXFLAGS: "-fPIC -g -O2 -std=c++11"
   CFLAGS: "-fPIC -g -O2"
   CMAKE_BUILD_TYPE: "RELEASE"
+  CMAKE_CXX_STANDARD: 11
 disable:
   - AliEn-Runtime
   - MonALISA-gSOAP-client
@@ -31,7 +32,7 @@ overrides:
   XRootD:
     tag: v4.8.3
   ROOT:
-    tag: "v6-18-00"
+    tag: "v6-20-04"
     source: https://github.com/root-project/root
     requires:
       - GSL

--- a/root.sh
+++ b/root.sh
@@ -39,8 +39,8 @@ unset ROOTSYS
 COMPILER_CC=cc
 COMPILER_CXX=c++
 COMPILER_LD=c++
-[[ "$CXXFLAGS" == *'-std=c++11'* ]] && CXX11=1 || true
-[[ "$CXXFLAGS" == *'-std=c++14'* ]] && CXX14=1 || true
+[[ "$CMAKE_CXX_STANDARD" == '11' ]] && CXX11=1 || true
+[[ "$CMAKE_CXX_STANDARD" == '14' ]] && CXX14=1 || true
 
 case $ARCHITECTURE in
   osx*)
@@ -93,8 +93,7 @@ else
         ${ALIEN_RUNTIME_ROOT:+-DMONALISA_DIR=$ALIEN_RUNTIME_ROOT} \
         ${XROOTD_ROOT:+-DXROOTD_ROOT_DIR=$XROOTD_ROOT}            \
 	${ALIEN_RUNTIME_ROOT:+-DXROOTD_ROOT_DIR=$ALIEN_RUNTIME_ROOT}\
-        ${CXX11:+-Dcxx11=ON}                                      \
-        ${CXX14:+-Dcxx14=ON}                                      \
+	-DCMAKE_CXX_STANDARD=$CMAKE_CXX_STANDARD                  \
         -Dfreetype=ON                                             \
         -Dbuiltin_freetype=OFF                                    \
         -Dpcre=OFF                                                \


### PR DESCRIPTION
This updates to the latest ROOT version and changes to the recommended way to select the ROOT C++ standard (old one still works for now, but will be deprecated in the near future).

Other packages are not affected (we should maybe move to a newer C++ standard though eventually).