### PR TITLE
Log4cpp

### DIFF
--- a/defaults-fairship-2018.sh
+++ b/defaults-fairship-2018.sh
@@ -132,10 +132,6 @@ overrides:
       prepend-path ROOT_INCLUDE_PATH \$::env(FAIRROOT_ROOT)/include
       $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH      \$::env(FAIRROOT_ROOT)/lib")
       EoF
-  log4cpp:
-    version: "%(tag_basename)s"
-    tag: REL_1_1_1_Nov_26_2013
-    source: https://github.com/ShipSoft/log4cpp
   GEANT4:
     version: "%(tag_basename)s"
     tag: v10.3.2

--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -128,10 +128,6 @@ overrides:
       prepend-path ROOT_INCLUDE_PATH \$::env(FAIRROOT_ROOT)/include
       $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH      \$::env(FAIRROOT_ROOT)/lib")
       EoF
-  log4cpp:
-    version: "%(tag_basename)s"
-    tag: REL_1_1_1_Nov_26_2013
-    source: https://github.com/ShipSoft/log4cpp
   GEANT4:
     version: "%(tag_basename)s"
     tag: v10.3.2

--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -1,7 +1,6 @@
 package: log4cpp
-version: "%(tag_basename)s%(defaults_upper)s"
-tag: REL_1_1_1_Nov_26_2013
-source: https://github.com/ShipSoft/log4cpp
+source: https://git.code.sf.net/p/log4cpp/codegit
+version: master
 requires:
   - GCC-Toolchain:(?!osx)
 build_requires:

--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -12,9 +12,7 @@ env:
 rsync -a $SOURCEDIR/* .
 ./autogen.sh
 ./configure          --prefix=$INSTALLROOT  \
-		     --enable-shared \
-		     --enable-static \
-		      CXX="g++" CC="gcc" CXXFLAGS="$CFLAGS"
+		     --enable-shared
 make ${JOBS+-j$JOBS}
 make install
 


### PR DESCRIPTION
This PR

* Updated the version of log4cpp to the master of the upstream repository
* Moves the configuration from the defaults to `log4cpp.sh`, (which were identical anyway, so there was no need to override it)
* Changes the configure flags of log4cpp to be the same as other packages (i.e. take `$CXX` and `$CXXFLAGS` from the environment)

This version should play nicer with newer C++ standards, see discussion in #55 .