### PR TITLE
Ensure python2 is used for lhapdf5

### DIFF
--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -10,21 +10,23 @@ requires:
 ---
 #!/bin/bash -ex
 
-rsync -a --exclude '**/.git' $SOURCEDIR/ ./
+rsync -a --exclude '**/.git' "$SOURCEDIR"/ ./
 
 export FFLAGS=--std=legacy
+PYTHON=$(command -v python2) && export PYTHON
 
-./configure --prefix=$INSTALLROOT
+./configure --prefix="$INSTALLROOT"
 
 make ${JOBS+-j $JOBS} all
 make install
 
 PDFSETS="cteq6l cteq6ll CT10 CT10nlo MSTW2008nnlo EPS09LOR_208 EPS09NLOR_208 cteq66a cteq66a0 cteq4m"
-pushd $INSTALLROOT/share/lhapdf
-  $INSTALLROOT/bin/lhapdf-getdata --repo=https://www.hepforge.org/archive/lhapdf/pdfsets/5.9.1 $PDFSETS
+pushd "$INSTALLROOT"/share/lhapdf
+  # shellcheck disable=SC2086
+  python2 "$INSTALLROOT"/bin/lhapdf-getdata --repo=https://www.hepforge.org/archive/lhapdf/pdfsets/5.9.1 $PDFSETS
   # Check if PDF sets were really installed
   for P in $PDFSETS; do
-    ls ${P}*
+    ls "${P}"*
   done
 popd
 


### PR DESCRIPTION
Instead of modifying unmaintained code to add python3 support ourselves (as done in https://github.com/ShipSoft/LHAPDF/commit/637eee3264959742774e475983a2f6ef8d6cb833), we can just force lhapdf5 to use python2 to retrieve the pdf sets. As far as I can tell, we don't rely on it's python module for any other purpose, so it's not an issue if it doesn't use python3.

Needless to say, this will only work with the unmodified lhapdf5 version. Hopefully we can move to lhapdf6 soon, so we can drop this outdated dependency.