### PR TITLE
Pin log4cpp commit

### DIFF
--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -1,6 +1,6 @@
 package: log4cpp
 source: https://git.code.sf.net/p/log4cpp/codegit
-version: master
+version: 1b9f8f7c031d6947c7468d54bc1da4b2f414558d
 requires:
   - GCC-Toolchain:(?!osx)
 build_requires:


### PR DESCRIPTION
As discussed in the meeting, this pins the commit of log4cpp we use to [log4cpp@`1b9f8f` from 2017](https://sourceforge.net/p/log4cpp/codegit/ci/1b9f8f7c031d6947c7468d54bc1da4b2f414558d/), the most recent one at the time of writing.