### PR TITLE
Use newest ROOT bugfix version

### DIFF
--- a/defaults-fairship.sh
+++ b/defaults-fairship.sh
@@ -32,7 +32,7 @@ overrides:
   XRootD:
     tag: v4.8.3
   ROOT:
-    tag: "v6-20-04"
+    tag: "v6-20-06"
     source: https://github.com/root-project/root
     requires:
       - GSL


### PR DESCRIPTION
[Various bugfixes](https://root.cern/doc/v620/release-notes.html#release-6.2006). Our stack and FairShip build fine (tested on Fedora 30), so I recommend we adopt them.

Early warning: The next major release, 6.22, was tagged and is available, but will require some changes on our side.