### PR TITLE
lhapdf5: point to python2 if python exists

### DIFF
--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -12,6 +12,9 @@ requires:
 
 rsync -a --exclude '**/.git' "$SOURCEDIR"/ ./
 
+# Point to right python version, if unversioned python exists
+command -v python >/dev/null 2>&1 && command -v python2 >/dev/null 2>&1 && PYTHON=$(command -v python2) && export PYTHON
+
 export FFLAGS=--std=legacy
 
 ./configure --prefix="$INSTALLROOT"


### PR DESCRIPTION
If `python` without a suffix does not exist, this is a no-op. If it does, PYTHON is set to the location of `python2` and exported.