### PR TITLE
Remove LHAPDF5 from madgraph; LHAPDF6 loaded by Pythia

### DIFF
--- a/madgraph5.sh
+++ b/madgraph5.sh
@@ -27,8 +27,7 @@ set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
 module load BASE/1.0                                                   \\
-	    ${PYTHIA_VERSION:+pythia/$PYTHIA_VERSION-$PYTHIA_REVISION} \\
-	    lhapdf5/${LHAPDF5_VERSION}-${LHAPDF5_REVISION}
+	    ${PYTHIA_VERSION:+pythia/$PYTHIA_VERSION-$PYTHIA_REVISION}
 # Our environment
 setenv MADGRAPH_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH \$::env(MADGRAPH_ROOT)/bin


### PR DESCRIPTION
Madgraph was still loading the old lhapdf5 (even though it's not defined as a dependency...).

As Pythia depends on lhapdf6 now, it should be loaded automatically when Madgraph loads Pythia.