### PR TITLE
fairship: need to set FAIRROOTPATH CMake variable

### DIFF
--- a/fairship.sh
+++ b/fairship.sh
@@ -94,6 +94,7 @@ rsync -a $SOURCEDIR/ $INSTALLROOT/
 
 cmake $SOURCEDIR                                                 \
       -DFAIRBASE="$FAIRROOT_ROOT/share/fairbase"                 \
+      -DFAIRROOTPATH="$FAIRROOTPATH"                             \
       -DFAIRROOT_INCLUDE_DIR="$FAIRROOT_ROOT/include"            \
       -DFAIRROOT_LIBRARY_DIR="$FAIRROOT_ROOT/lib"                \
       -DFAIRLOGGER_INCLUDE_DIR="$FAIRLOGGER_ROOT/include"        \


### PR DESCRIPTION
For some reason CMake needs both the environment variable AND the CMake variable. Either alone is insufficient (even though they point to the same path...).

See https://github.com/SND-LHC/snddist/pull/14