### PR TITLE
autotools.sh: Fix encoding bug

### DIFF
--- a/autotools.sh
+++ b/autotools.sh
@@ -49,6 +49,7 @@ fi
 
 # m4 -- requires: nothing special
 pushd m4*
+  sed -i '1 i @documentencoding ISO-8859-1' doc/m4.texi
   $USE_AUTORECONF && autoreconf -ivf
   ./configure --disable-dependency-tracking --prefix $INSTALLROOT
   make ${JOBS+-j $JOBS}


### PR DESCRIPTION
@evanherwijnen identified an issue when building autotools.

This fixes it in his case, and should be a no-op in the cases where it build fine anyway,

Explanation:
- `m4.texi` is encoded using ISO-8859-1
- recent `texinfo` versions assume unicode by default and crash when encountering ISO-8859-1 instead (at least in this case)
- explicitly specifying the encoding should always (?) work