### PR TITLE
Ubuntu22 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,12 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Fixed
 
+* bz2: version number set to string (1.0 -> "1.0")
+
 ### Changed
 
-* Geant4: Update to 10.7.3, as required for Ubuntu22
-
-* Python-modules-list: scikit-learn and sklearn-evaluation module version requirement reduced from == to >=
-
-* bz2: version number set to string (1.0 -> "1.0")
+* Geant4: Update to 10.7.3, as required for Ubuntu 22.04
+* Python-modules-list: scikit-learn and sklearn-evaluation module version requirement relaxed from == to >=
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 * Python-modules-list: scikit-learn and sklearn-evaluation module version requirement reduced from == to >=
 
+* bz2: version number set to string (1.0 -> "1.0")
+
 ### Removed
 
 ## [24.05.1](https://github.com/ShipSoft/shipdist/tree/24.05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Changed
 
+* Geant4: Update to 10.7.3, as required for Ubuntu22
+
+* Python-modules-list: scikit-learn and sklearn-evaluation module version requirement reduced from == to >=
+
 ### Removed
 
 ## [24.05.1](https://github.com/ShipSoft/shipdist/tree/24.05)

--- a/bz2.sh
+++ b/bz2.sh
@@ -1,5 +1,5 @@
 package: bz2
-version: 1.0
+version: "1.0"
 system_requirement_missing: |
   Please install bzip2 development package on your system:
     * On RHEL-compatible systems: bzip2-devel

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -104,7 +104,7 @@ overrides:
       grep 1.9.0 $FAIRLOGGER_ROOT/include/fairlogger/Version.h
   GEANT4:
     version: "%(tag_basename)s"
-    tag: v10.7.2
+    tag: v10.7.3
     source: https://github.com/geant4/geant4.git
     prefer_system_check: |
       ls $GEANT4_ROOT/bin > /dev/null && \

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -105,8 +105,8 @@ env:
     scipy==1.9.3
     Cython==0.29.21
     seaborn==0.11.0
-    scikit-learn==0.24.1
-    sklearn-evaluation==0.8.1
+    scikit-learn>=0.24.1
+    sklearn-evaluation>=0.8.1
     Keras==2.4.3
     xgboost==1.2.0
     dryable==1.0.5


### PR DESCRIPTION
Dear all FairShip users,

I have performed a test build of FairShip in ubuntu22, with @olantwin 's assistance.

Everything went pretty much normally, apart from two issues:

1. Geant4 10.7.2 compilation error, with error: `ambiguating new declaration of 'G4double fsqrt(G4double)'. `
Already known in Geant4, and solved just by using the next version 10.7.3 (https://geant4-forum.web.cern.ch/t/compiling-10-07-p01-on-ubuntu-22-04/7848)
2. Python-modules-list build error, due to fails in scikit-learn. Solved by changing the version requirements from == to >=.

Please let me know if you have any question or suggestion.

Best Regards,
Antonio