### PR TITLE
Python-modules: Remove obsolete workaround for scikit-garden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Fixed
 
+* Python-modules: Remove obsolete workaround for scikit-garden
+  Installing numpy without specifying the version ahead of the other
+  dependencies lead to the  installation of two conflicting numpy versions, one
+  of which broke matplotlib.
+
 ### Changed
 
 ### Removed

--- a/python-modules-list.sh
+++ b/python-modules-list.sh
@@ -50,7 +50,7 @@ env:
     PyYAML==6.0.1
     psutil==5.8.0
     uproot==4.1.0
-    numpy==1.21.4
+    numpy==1.21.6
     scipy==1.7.3
     Cython==0.29.21
     seaborn==0.11.0

--- a/python-modules.sh
+++ b/python-modules.sh
@@ -66,11 +66,6 @@ esac | tr -s '[:space:]' '\n' > requirements.txt
 # Install pinned basic requirements for python infrastructure
 python3 -m pip install -IU -r base-requirements.txt
 
-# FIXME: required because of the newly introduced dependency on scikit-garden requires
-# a numpy to be installed separately
-# See also:
-#   https://github.com/scikit-garden/scikit-garden/issues/23
-python3 -m pip install -IU numpy
 python3 -m pip install -IU -r requirements.txt
 
 # Find the proper Python lib library and export it


### PR DESCRIPTION
Installing numpy without specifying the version ahead of the other dependencies lead to the  installation of two conflicting numpy versions, one of which broke matplotlib.