### PR TITLE
XRootD: Update to 5.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Changed
 
+* XRootD: Update to 5.7.1
+
 ### Removed
 
 ## [24.09](https://github.com/ShipSoft/shipdist/tree/24.09)

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.7.0"
+tag: "v5.7.1"
 source: https://github.com/xrootd/xrootd
 requires:
   - "OpenSSL:(?!osx)"


### PR DESCRIPTION
Routine version bump. Changelog: https://github.com/xrootd/xrootd/releases/tag/v5.7.1