### PR TITLE
FairRoot: Use patched 18.6.10 to allow building without Geant3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 ### Changed
 
 * ROOT: Update recipe and version to 6.30.8
+* FairRoot: Use patched 18.6.10 to allow building without Geant3
 
 ### Removed
 

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,7 +1,7 @@
 package: FairRoot
 version: "%(short_hash)s"
-tag: "v18.6.10"
-source: https://github.com/FairRootGroup/FairRoot
+tag: "v18.6.10_ship"
+source: https://github.com/ShipSoft/FairRoot
 requires:
   - generators
   - simulation
@@ -20,6 +20,7 @@ env:
   FAIRROOTPATH: "$FAIRROOT_ROOT"
 prepend_path:
   ROOT_INCLUDE_PATH: "$FAIRROOT_ROOT/include"
+  LD_LIBRARY_PATH: "$FAIRROOT_ROOT/lib"
 ---
 # Making sure people do not have SIMPATH set when they build fairroot.
 # Unfortunately SIMPATH seems to be hardcoded in a bunch of places in


### PR DESCRIPTION
Stack changes for https://github.com/ShipSoft/FairShip/pull/588