### PR TITLE
Add linter to CI

### DIFF
--- a/.github/workflows/recipe-checks.yml
+++ b/.github/workflows/recipe-checks.yml
@@ -1,0 +1,76 @@
+---
+# GitHub workflow to check pull requests and commits for pitfalls and formatting
+# mistakes in build recipes.
+name: Check recipes
+
+'on':
+  push:
+    paths:
+      - '*.sh'
+  pull_request:
+    paths:
+      - '*.sh'
+
+permissions: {}
+
+jobs:
+  lint:
+    name: alidistlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install dependencies
+        run: python3 -m pip install -U --user 'alidistlint[git]'
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run linter
+        run: |
+          if [ -n "$BASE_SHA" ]; then
+            # For pull requests, only check files that have changed relative to
+            # the base commit.
+            merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+            git diff -z --diff-filter d --name-only "$merge_base..$HEAD_SHA" -- '*.sh' |
+              xargs -0tr alidistlint -f github --changes "$merge_base..$HEAD_SHA"
+          else
+            # On push, check every file, ignoring warnings and notes.
+            alidistlint -ef github ./*.sh
+          fi
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.sha }}
+
+  circular:
+    name: circular dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y graphviz
+          python3 -m pip install -U --user alibuild
+          aliBuild analytics off
+
+      - uses: actions/checkout@v3
+
+      - name: Run check
+        run: |
+          for fname in *.sh; do
+            case "$fname" in
+              jalien*) default=jalien ;;
+              *) default=o2 ;;
+            esac
+            echo "Checking $fname with --defaults $default"
+            if aliBuild deps --defaults "$default" --outgraph /dev/null --no-system --neat -c . \
+                        "$(awk '/^package: /{print $2}' "$fname")" 2>&1 |
+               grep -q 'transitive reduction not unique'
+            then
+              echo -n "::error title=circular dependency,file=$fname,line=1"
+              echo '::recipe has circular dependency'
+              err=1
+            fi
+          done
+          exit "${err:-0}"


### PR DESCRIPTION
As used in https://github.com/alisw/alidist. Should prevent issues like https://github.com/ShipSoft/shipdist/commit/91430544050b01a77d1a678fc16fae222a105533

There are a few failing lints currently, if there's interest in merging this PR I wouldn't mind fixing them myself (but it will trigger a big rebuild)

```
$ alidistlint -f gcc *.sh | grep error:
genie.sh:1:0: error: metadata not found or empty (is the '\n---\n' separator present?) [ali:empty]
glog.sh:1:0: error: metadata not found or empty (is the '\n---\n' separator present?) [ali:empty]
mesos-workqueue.sh:1:0: error: metadata not found or empty (is the '\n---\n' separator present?) [ali:empty]
pda.sh:1:0: error: metadata not found or empty (is the '\n---\n' separator present?) [ali:empty]
aliroot-coverage.sh:3:1: error: force_rebuild: must be of boolean type [ali:schema]
aliroot-guntest.sh:3:1: error: force_rebuild: must be of boolean type [ali:schema]
aliroot-test.sh:3:1: error: force_rebuild: must be of boolean type [ali:schema]
defaults-release.sh:7:3: error: env.CMAKE_CXX_STANDARD: must be of string type [ali:schema]
epos-test.sh:3:1: error: force_rebuild: must be of boolean type [ali:schema]
genfit.sh:8:1: error: build-requires: unknown field [ali:schema]
igprof-packaging.sh:4:1: error: force_rebuild: must be of boolean type [ali:schema]
libperl.sh:2:1: error: version: must be of string type [ali:schema]
o2checkcode.sh:7:1: error: force_rebuild: must be of boolean type [ali:schema]
osx-system-openssl.sh:2:1: error: version: must be of string type [ali:schema]
rivet-test.sh:3:1: error: force_rebuild: must be of boolean type [ali:schema]
sip-check.sh:2:1: error: version: must be of string type [ali:schema]
template-recipe.sh:1:1: error: package: must match the file name 'template-recipe.sh' case-insensitively, excluding the .sh [ali:schema]
termcap.sh:2:1: error: version: must be of string type [ali:schema]
thepeg-test.sh:3:1: error: force_rebuild: must be of boolean type [ali:schema]
yacc-like.sh:2:1: error: version: must be of string type [ali:schema]
alien-cas.sh:4:47: error: trailing spaces [yl:trailing-spaces]
aliroot-csa.sh:9:45: error: trailing spaces [yl:trailing-spaces]
defaults-release.sh:145:27: error: trailing spaces [yl:trailing-spaces]
defaults-release.sh:247:48: error: trailing spaces [yl:trailing-spaces]
defaults-release.sh:248:3: error: duplication of key "vgm" in mapping [yl:key-duplicates]
fairmq.sh:22:3: error: duplication of key "ROOT_INCLUDE_PATH" in mapping [yl:key-duplicates]
flpproto.sh:18:1: error: too many blank lines (1 > 0) [yl:empty-lines]
hijing.sh:8:1: error: too many blank lines (1 > 0) [yl:empty-lines]
kernel-devel.sh:7:1: error: too many blank lines (1 > 0) [yl:empty-lines]
parquet-cpp.sh:9:1: error: duplication of key "build_requires" in mapping [yl:key-duplicates]
mesos-workqueue.sh:3:17: error: '(' is invalid here. Did you forget to escape it? [SC1036]
mesos-workqueue.sh:3:17: error: Parsing stopped here. Invalid use of parentheses? [SC1088]
autotools.sh:41:9: error: -d doesn't work with globs. Use a for loop. [SC2144]
```

Copying @ktf too
