### PR TITLE
FairRoot: update to 18.8.2, return to upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Added
 
+* Readd support for GEANT3, to allow using upstream FairRoot
+
 ### Fixed
 
 * Freetype & XDevel: Fix freetype detection
@@ -19,10 +21,10 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 ### Changed
 
 * ROOT: Update recipe and version to 6.30.8
-* FairRoot: Use patched 18.6.10 to allow building without Geant3
 * vgm: update to v4-9 to support C++17
 * ROOT: Explicitly enable PROOF for newer ROOT versions
 * Root: Check version, features
+* FairRoot: Update to 18.8.2
 
 ### Removed
 

--- a/defaults-release.sh
+++ b/defaults-release.sh
@@ -274,6 +274,17 @@ overrides:
       ls $XERCESC_ROOT/lib/libxerces-c.a > /dev/null && \
       ls $XERCESC_ROOT/lib/libxerces-c.la > /dev/null && \
       ls $XERCESC_ROOT/lib/libxerces-c.so > /dev/null
+  GEANT3:
+    version: "%(tag_basename)s"
+    source: https://github.com/vmc-project/geant3
+    tag: v3-9
+    prefer_system_check: |
+      ls $GEANT3_ROOT/ > /dev/null && \
+      ls $GEANT3_ROOT/include > /dev/null && \
+      ls $GEANT3_ROOT/include/TGeant3 > /dev/null && \
+      ls $GEANT3_ROOT/include/TGeant3/TGeant3.h > /dev/null && \
+      ls $GEANT3_ROOT/lib64/libgeant321.so > /dev/null && \
+      true
   googletest:
     prefer_system_check: |
       ls $GOOGLETEST_ROOT/ > /dev/null && \

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,7 +1,7 @@
 package: FairRoot
-version: "%(short_hash)s"
-tag: "v18.6.10_ship"
-source: https://github.com/ShipSoft/FairRoot
+version: "v18.8.2"
+tag: "v18.8.2"
+source: https://github.com/FairRootGroup/FairRoot
 requires:
   - generators
   - simulation
@@ -51,6 +51,7 @@ cmake $SOURCEDIR                                                                
       -DROOT_CONFIG_SEARCHPATH=$ROOT_ROOT/bin                                               \
       -DPythia6_LIBRARY_DIR=$PYTHIA6_ROOT/lib                                               \
       ${YAML_CPP_ROOT:+-DYAML_CPP_ROOT=$YAML_CPP_ROOT}                                      \
+      -DGeant3_DIR=$GEANT3_ROOT                                                             \
       -DDISABLE_GO=ON                                                                       \
       -DBUILD_EXAMPLES=ON                                                                   \
       ${GEANT4_ROOT:+-DGeant4_DIR=$GEANT4_ROOT}                                             \
@@ -98,6 +99,7 @@ module load BASE/1.0                                                            
             ${YAML_CPP_REVISION:+yaml-cpp/$YAML_CPP_VERSION-$YAML_CPP_REVISION}                  \\
             ${FAIRLOGGER_REVISION:+FairLogger/$FAIRLOGGER_VERSION-$FAIRLOGGER_REVISION}         \\
             ${FAIRMQ_REVISION:+FairMQ/$FAIRMQ_VERSION-$FAIRMQ_REVISION}                         \\
+            ${GEANT3_REVISION:+GEANT3/$GEANT3_VERSION-$GEANT3_REVISION}                         \\
             ${GEANT4_VMC_REVISION:+GEANT4_VMC/$GEANT4_VMC_VERSION-$GEANT4_VMC_REVISION}         \\
             ${PROTOBUF_REVISION:+protobuf/$PROTOBUF_VERSION-$PROTOBUF_REVISION}                 \\
             ${PYTHIA6_REVISION:+pythia6/$PYTHIA6_VERSION-$PYTHIA6_REVISION}                     \\

--- a/geant3.sh
+++ b/geant3.sh
@@ -1,0 +1,52 @@
+package: GEANT3
+version: "%(tag_basename)s"
+tag: v3-9
+requires:
+  - ROOT
+  - VMC
+build_requires:
+  - CMake
+  - "Xcode:(osx.*)"
+source: https://github.com/vmc-project/geant3
+prepend_path:
+  LD_LIBRARY_PATH: "$GEANT3_ROOT/lib64"
+  ROOT_INCLUDE_PATH: "$GEANT3_ROOT/include/TGeant3"
+---
+#!/bin/bash -e
+FVERSION=`gfortran --version | grep -i fortran | sed -e 's/.* //' | cut -d. -f1`
+SPECIALFFLAGS=""
+if [ $FVERSION -ge 10 ]; then
+   echo "Fortran version $FVERSION"
+   SPECIALFFLAGS=1
+fi
+cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT      \
+                 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE     \
+                 ${CXXSTD:+-DCMAKE_CXX_STANDARD=$CXXSTD}  \
+                 -DCMAKE_SKIP_RPATH=TRUE \
+                 ${SPECIALFFLAGS:+-DCMAKE_Fortran_FLAGS="-fallow-argument-mismatch -fallow-invalid-boz -fno-tree-loop-distribute-patterns"}
+make ${JOBS:+-j $JOBS} install
+
+[[ ! -d $INSTALLROOT/lib64 ]] && ln -sf lib $INSTALLROOT/lib64
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION VMC/$VMC_VERSION-$VMC_REVISION
+# Our environment
+set GEANT3_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+setenv GEANT3_ROOT \$GEANT3_ROOT
+setenv GEANT3DIR \$GEANT3_ROOT
+setenv G3SYS \$GEANT3_ROOT
+prepend-path LD_LIBRARY_PATH \$GEANT3_ROOT/lib64
+prepend-path ROOT_INCLUDE_PATH \$GEANT3_ROOT/include/TGeant3
+EoF


### PR DESCRIPTION
This also readds the GEANT3 recipe, as it is needed by upstream FairRoot.