### PR TITLE
Pin npdb-client version

### DIFF
--- a/npdb-client.sh
+++ b/npdb-client.sh
@@ -1,6 +1,6 @@
 package: npdb-client
-version: "0.1.1"
-tag: master
+version: "0.2.0"
+tag: "0.2.0"
 source: https://gitlab.cern.ch/ship/computing/npdb
 build_requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
With version `0.2.0` I'll be committing to a more rigorous releases, so let's pin it now.

https://gitlab.cern.ch/ship/computing/npdb/-/tree/0.2.0?ref_type=tags