### PR TITLE
feat(boost): Update to 1.75.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 * XRootD: Update to 5.8.4
 * autotools: Update to 1.6.4
 * CMake: Update to 3.26.5 (match SLC9)
+* boost: Update to 1.75.0 (match SLC9 version)
 
 ## [25.08](https://github.com/ShipSoft/shipdist/tree/25.08)
 

--- a/boost.sh
+++ b/boost.sh
@@ -1,6 +1,6 @@
 package: boost
 version: "%(tag_basename)s"
-tag: "v1.70.0"
+tag: "v1.75.0"
 source: https://github.com/alisw/boost.git
 requires:
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Aligns with SLC9 (where we use it from the system). Also needed for Ubuntu (see #119 )