### PR TITLE
feat(GCC): Update to v11.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 * autotools: Update to 1.6.4
 * CMake: Update to 3.26.5 (match SLC9)
 * boost: Update to 1.75.0 (match SLC9 version)
+* GCC: Update to v11.2.0 when not using system toolchain
 
 ## [25.08](https://github.com/ShipSoft/shipdist/tree/25.08)
 

--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -1,6 +1,6 @@
 package: GCC-Toolchain
 version: "%(tag_basename)s"
-tag: v7.3.0-alice2
+tag: alice/v11
 source: https://github.com/alisw/gcc-toolchain
 prepend_path:
   "LD_LIBRARY_PATH": "$GCC_TOOLCHAIN_ROOT/lib64"


### PR DESCRIPTION
This matches (more or less) the SLC9 version (11.5), which we use on lxplus.