### PR TITLE
Update to FairShip override in defaults-actstracking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
   - FairMQ: Updated recipe version from v1.4.49 to v1.4.38 to match defaults
   - Tauolapp: Updated recipe version format and tag from v1.1.5 to v1.1.5-ship to match defaults
   - pythia6: Updated recipe tag from 428-alice1 to v6.4.28-snd and source from alisw/pythia6.git to SND-LHC/pythia6 to match defaults
+  - defaults-actstracking.sh: FairShip override removed.
 * Python-modules-list: Updated pip to v25.0.1
 * Python-modules-list: Added pybind11 v2.13.6
 * EvtGen: Added cmake build instructions required for R02-02-00

--- a/defaults-actstracking.sh
+++ b/defaults-actstracking.sh
@@ -58,8 +58,8 @@ overrides:
     version: "%(tag_basename)s"
     tag: "v3.12.3"
   FairShip:
-    tag: pythia_update
-    source: https://github.com/webbjm/FairShip
+    tag: master
+    source: https://github.com/ShipSoft/FairShip
     requires:
       - generators
       - simulation


### PR DESCRIPTION
FairShip override in defaults-actstracking updated to use master. Forked version no longer required as pythia8.3+ now supported by master. 