### PR TITLE
ACTS python packages loaded by recipe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 * FairRoot: Add missing GEANT3 dependency
 * EvtGen: Fix detection of C++11
 * ACTS/Eigen3/Hepmc3: Fixed module detection
+* ACTS: PYTHONPATH set in recipe
 * FairShip: Find python paths correctly
 
 ### Changed

--- a/acts.sh
+++ b/acts.sh
@@ -45,4 +45,5 @@ set ACTS_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 setenv ACTS_ROOT \$ACTS_ROOT
 prepend-path LD_LIBRARY_PATH \$ACTS_ROOT/lib
 prepend-path ROOT_INCLUDE_PATH \$ACTS_ROOT/include
+prepend-path PYTHONPATH \$ACTS_ROOT/python
 EoF


### PR DESCRIPTION
ACTS python packages made available through setting PYTHONPATH within recipe.
Sourcing setup bash script no longer required.