### PR TITLE
feat: add DD4hep v01-33 recipe with TBB and Geant4 compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Added
 
+* DD4hep: Add recipe for detector description toolkit (v01-33)
 * ACTS: Standalone recipe for new tracking framework
 * HEPMC3: Recipe, required dependency for ACTS
 * EIGEN3: Recipe, required dependency for ACTS
@@ -24,6 +25,8 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Fixed
 
+* DD4hep: Fix TBB linking by manually setting TBB_IMPORTED_TARGETS for modern oneTBB compatibility
+* DD4hep: Fix compilation flag concatenation bug by adding whitespace to Geant4 exported CXX_FLAGS to prevent improper flag merging in DD4hep's CMake code
 * ROOT: Disabled davix to resolve build issues
 * FairRoot: Add missing GEANT3 dependency
 * EvtGen: Fix detection of C++11
@@ -33,6 +36,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Changed
 
+* FairShip: Add DD4hep as required dependency
 * Defaults: Moved all overrides from defaults files to individual recipes to reduce duplication
   - defaults-release.sh: Moved all 12 package overrides to their respective recipe files, leaving only environment configuration
   - boost: Updated recipe from v1.75.0 to v1.70.0 and moved version, tag, requires, and prefer_system_check to recipe

--- a/dd4hep.sh
+++ b/dd4hep.sh
@@ -1,0 +1,71 @@
+package: DD4hep
+version: "%(tag_basename)s"
+tag: v01-33
+source: https://github.com/AIDASoft/DD4hep
+requires:
+  - ROOT
+  - boost
+  - GEANT4
+  - XercesC
+  - TBB
+build_requires:
+  - CMake
+env:
+  DD4HEP: "$DD4HEP_ROOT"
+  DD4hepINSTALL: "$DD4HEP_ROOT"
+prepend_path:
+  ROOT_INCLUDE_PATH: "$DD4HEP_ROOT/include"
+  PATH: "$DD4HEP_ROOT/bin"
+  LD_LIBRARY_PATH: "$DD4HEP_ROOT/lib"
+---
+#!/bin/bash -e
+
+# Fix Geant4 exported flags to prevent concatenation bugs in DD4hep's CMake
+# Add trailing space to Geant4_CXX_FLAGS and leading space to build-type-specific flags
+# This ensures proper separation when DD4hep concatenates them
+if [ -n "$GEANT4_ROOT" ]; then
+  find "$GEANT4_ROOT" -name "Geant4Config.cmake" -exec sed -i.bak \
+    -e 's/set(Geant4_CXX_FLAGS "\(.*\)")/set(Geant4_CXX_FLAGS "\1 ")/' \
+    -e 's/set(Geant4_CXX_FLAGS_RELEASE "\(.*\)")/set(Geant4_CXX_FLAGS_RELEASE " \1")/' \
+    -e 's/set(Geant4_CXX_FLAGS_DEBUG "\(.*\)")/set(Geant4_CXX_FLAGS_DEBUG " \1")/' \
+    -e 's/set(Geant4_CXX_FLAGS_RELWITHDEBINFO "\(.*\)")/set(Geant4_CXX_FLAGS_RELWITHDEBINFO " \1")/' \
+    -e 's/set(Geant4_CXX_FLAGS_MINSIZEREL "\(.*\)")/set(Geant4_CXX_FLAGS_MINSIZEREL " \1")/' \
+    {} \;
+fi
+
+cmake "$SOURCEDIR" \
+      -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE} \
+      ${CMAKE_CXX_STANDARD:+-DCMAKE_CXX_STANDARD=$CMAKE_CXX_STANDARD} \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
+      -DDD4HEP_USE_XERCESC=ON \
+      -DDD4HEP_USE_GEANT4=ON \
+      -DDD4HEP_USE_TBB=ON \
+      -DDD4HEP_USE_EDM4HEP=OFF \
+      -DDD4HEP_USE_LCIO=OFF \
+      -DDD4HEP_USE_HEPMC3=OFF \
+      -DDD4HEP_BUILD_EXAMPLES=OFF \
+      -DDD4HEP_SET_RPATH=OFF \
+      -DTBB_IMPORTED_TARGETS="TBB::tbb" \
+      ${BOOST_ROOT:+-DBoost_ROOT=$BOOST_ROOT} \
+      ${ROOT_ROOT:+-DROOT_DIR=$ROOT_ROOT} \
+      ${GEANT4_ROOT:+-DGeant4_DIR=$GEANT4_ROOT} \
+      ${XERCESC_ROOT:+-DXercesC_DIR=$XERCESC_ROOT} \
+      ${TBB_ROOT:+-DTBB_DIR=$TBB_ROOT/lib/cmake/TBB}
+
+cmake --build . ${JOBS:+-j$JOBS}
+cmake --install .
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module --bin --lib > "$MODULEFILE"
+cat >> "$MODULEFILE" <<EoF
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
+prepend-path CMAKE_PREFIX_PATH \$PKG_ROOT
+setenv DD4HEP \$PKG_ROOT
+setenv DD4hepINSTALL \$PKG_ROOT
+EoF

--- a/fairship.sh
+++ b/fairship.sh
@@ -14,6 +14,7 @@ requires:
   - EvtGen
   - ROOT
   - VMC
+  - DD4hep
 env:
   FAIRSHIP: "$FAIRSHIP_ROOT"
   EOSSHIP: "root://eospublic.cern.ch/"
@@ -56,7 +57,8 @@ incremental_recipe: |
             ${FAIRROOT_VERSION:+FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION} \\
             ${GENFIT_VERSION:+GenFit/$GENFIT_VERSION-$GENFIT_REVISION} \\
             ${HEPMC3_VERSION:+HepMC3/$HEPMC3_VERSION-$HEPMC3_REVISION} \\
-            ${ACTS_VERSION:+acts/$ACTS_VERSION-$ACTS_REVISION}
+            ${ACTS_VERSION:+acts/$ACTS_VERSION-$ACTS_REVISION} \\
+            ${DD4HEP_VERSION:+DD4hep/$DD4HEP_VERSION-$DD4HEP_REVISION}
   # Our environment
   setenv EOSSHIP root://eospublic.cern.ch/
   setenv FAIRSHIP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
@@ -107,6 +109,7 @@ cmake $SOURCEDIR                                                 \
       ${BOOST_ROOT:+-DBOOST_ROOT=$BOOST_ROOT}                    \
       ${GENFIT:+-Dgenfit2_ROOT=$GENFIT} \
       ${ACTS:+-DACTS_ROOT=$ACTS_ROOT} \
+      ${DD4HEP_ROOT:+-DDD4hep_DIR=$DD4HEP_ROOT} \
       -DCMAKE_INSTALL_PREFIX=$INSTALLROOT
 
 cmake --build . ${JOBS+-j$JOBS} --target install
@@ -137,7 +140,8 @@ module load BASE/1.0                                                            
             ${FAIRROOT_VERSION:+FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION}	\\
             ${GENFIT_VERSION:+GenFit/$GENFIT_VERSION-$GENFIT_REVISION} \\
             ${HEPMC3_VERSION:+HepMC3/$HEPMC3_VERSION-$HEPMC3_REVISION} \\
-            ${ACTS_VERSION:+acts/$ACTS_VERSION-$ACTS_REVISION}
+            ${ACTS_VERSION:+acts/$ACTS_VERSION-$ACTS_REVISION} \\
+            ${DD4HEP_VERSION:+DD4hep/$DD4HEP_VERSION-$DD4HEP_REVISION}
 
 # Our environment
 setenv EOSSHIP root://eospublic.cern.ch/


### PR DESCRIPTION
- Add DD4hep v01-33 recipe for detector description toolkit
- Fix TBB linking by manually setting TBB_IMPORTED_TARGETS for modern oneTBB
- Fix Geant4 flag concatenation bug by adding whitespace to exported CXX_FLAGS
- Add DD4hep as required dependency for FairShip
- Update CHANGELOG with DD4hep addition and fixes

@matclim