### PR TITLE
feat(protobuf): update to v33.5, migrate to CMake build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 ### Added
 
 * Add pre-commit to python modules
+* abseil: Add recipe for protobuf dependency
 
 ### Fixed
 
@@ -74,6 +75,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ### Changed
 
+* protobuf: Update to v33.5, migrate from autotools to CMake build
 * Move to C++20
 * ROOT: Update to 6.36.08
 * defaults-actstracking: Remove all overrides unrelated to ACTS or C++20


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Abseil recipe support.

* **Updated Dependencies**
  * Upgraded Protobuf to v33.5.
  * Modernized Protobuf build system with CMake/Ninja.
  * Updated library discovery environment paths.

* **Documentation**
  * Updated CHANGELOG with recipe changes and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->