### PR TITLE
Disable HepMC3 Python bindings to avoid installing into system prefix

### DIFF
--- a/hepmc3.sh
+++ b/hepmc3.sh
@@ -22,6 +22,7 @@ alibuild-generate-module --bin --lib > "${MODULEFILE}"
 cmake  "$SOURCEDIR"                           \
        -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"  \
        -DCMAKE_INSTALL_LIBDIR=lib           \
+       -DHEPMC3_ENABLE_PYTHON=OFF           \
        -DROOT_DIR="$ROOT_ROOT"
 
 make ${JOBS+-j $JOBS}


### PR DESCRIPTION
The Python bindings try to install into the LCG Python site-packages directory which is read-only. Only the C++ libraries are needed.