### PR TITLE
feat(yaml-cpp): update to 0.8.0, remove boost dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 * APFEL: Upgrade to 3.1.1 and switch to CMake build
 * ROOT, Geant4: Build with Ninja
 * FairLogger: Update to v2.3.1
+* yaml-cpp: Update to 0.8.0, remove obsolete boost dependency
 * FairShip: Build with Ninja
 * Refactor modulefiles to use alibuild-generate-module
 * FairRoot: Remove unused FairMQ dependency

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -7,6 +7,7 @@ build_requires:
   - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
+  REQUESTED_VERSION=${REQUESTED_VERSION#v}
   pkg-config --atleast-version=$REQUESTED_VERSION yaml-cpp &&
     printf "#include \"yaml-cpp/yaml.h\"\n" |
     c++ -std=c++17 -xc++ - -c -o /dev/null
@@ -18,7 +19,7 @@ cmake $SOURCEDIR                                         \
   -DBUILD_SHARED_LIBS=YES                                \
   -DCMAKE_SKIP_RPATH=YES                                 \
   -DYAML_CPP_BUILD_TESTS=NO                              \
-  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5                     \
   -DSKIP_INSTALL_FILES=1
 
 make ${JOBS+-j $JOBS} install

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -1,25 +1,21 @@
 package: yaml-cpp
 version: "%(tag_basename)s"
-tag: yaml-cpp-0.6.3
+tag: 0.8.0
 source: https://github.com/jbeder/yaml-cpp
-requires:
-  - boost
 build_requires:
   - CMake
   - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
-  pkg-config --atleast-version=0.6.2 yaml-cpp &&
+  pkg-config --atleast-version=$REQUESTED_VERSION yaml-cpp &&
     printf "#include \"yaml-cpp/yaml.h\"\n" |
-    c++ -std=c++17 -I$BOOST_ROOT/include -xc++ - -c -o /dev/null
+    c++ -std=c++17 -xc++ - -c -o /dev/null
 ---
 #!/bin/sh
+
 cmake $SOURCEDIR                                         \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"             \
   -DBUILD_SHARED_LIBS=YES                                \
-  ${BOOST_ROOT:+-DBOOST_ROOT:PATH="$BOOST_ROOT"}         \
-  ${BOOST_ROOT:+-DBoost_DIR:PATH="$BOOST_ROOT"}          \
-  ${BOOST_ROOT:+-DBoost_INCLUDE_DIR:PATH="$BOOST_ROOT/include"}  \
   -DCMAKE_SKIP_RPATH=YES                                 \
   -DYAML_CPP_BUILD_TESTS=NO                              \
   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \


### PR DESCRIPTION
## Summary
- Update yaml-cpp to 0.8.0
- Remove obsolete boost dependency (no longer needed since yaml-cpp 0.6.0)

## Test plan
- [x] Build yaml-cpp and dependents (lhapdf, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated yaml-cpp to version 0.8.0.
  * Removed the Boost dependency requirement to simplify external dependencies and installation.
  * Simplified packaging and module-loading configuration to reduce setup complexity and make installations more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->