### PR TITLE
refactor: remove macOS support and modernise modulefiles

### DIFF
--- a/abseil.sh
+++ b/abseil.sh
@@ -2,7 +2,7 @@ package: abseil
 version: "%(tag_basename)s"
 tag: "20240722.0"
 requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
 source: https://github.com/abseil/abseil-cpp
 build_requires:
   - CMake

--- a/apfel.sh
+++ b/apfel.sh
@@ -6,6 +6,7 @@ requires:
   - lhapdf
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 env:
   LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$APFEL_ROOT/lib"
 prefer_system_check: |
@@ -29,20 +30,5 @@ cmake -S $SOURCEDIR -B .                                        \
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Environment
-setenv APFEL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$::env(APFEL_ROOT)/lib
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/autotools.sh
+++ b/autotools.sh
@@ -4,16 +4,18 @@ tag: v1.6.4
 source: https://github.com/alisw/autotools
 prefer_system: "(?!slc5|slc6)"
 prefer_system_check: |
-  if ! (which autoconf && which m4 && which automake && which makeinfo && which aclocal && which pkg-config && which autopoint && which libtool); then
-    cat <<\EOF
+  for bin in autoconf m4 automake makeinfo aclocal pkg-config autopoint libtool; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+      cat <<\EOF
   One or more autotools packages are missing on your system.
    * On a RHEL-compatible system you probably need:
      autoconf automake texinfo gettext gettext-devel libtool
    * On an Ubuntu-like system you probably need:
      autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config
   EOF
-    exit 1
-  fi
+      exit 1
+    fi
+  done
 prepend_path:
   PKG_CONFIG_PATH: $(pkg-config --debug 2>&1 | grep 'Scanning directory' | sed -e "s/.*'\(.*\)'/\1/" | xargs echo | sed -e 's/ /:/g')
 build_requires:
@@ -150,11 +152,11 @@ pushd pkg-config*
 popd
 
 # Fix perl location, required on /usr/bin/perl
-grep -l -R -e '^#!.*perl' $INSTALLROOT | \
-  xargs -r -n1 sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/perl;'
+grep -rlZ -e '^#!.*perl' $INSTALLROOT | \
+  xargs -r -0 -n1 sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/perl;'
 find $INSTALLROOT -name '*deleteme' -delete
-grep -l -R -e 'exec [^ ]*/perl' $INSTALLROOT | \
-  xargs -r -n1 sed -ideleteme -e 's;exec [^ ]*/perl;exec /usr/bin/perl;g'
+grep -rlZ -e 'exec [^ ]*/perl' $INSTALLROOT | \
+  xargs -r -0 -n1 sed -ideleteme -e 's;exec [^ ]*/perl;exec /usr/bin/perl;g'
 find $INSTALLROOT -name '*deleteme' -delete
 
 # Pretend we have a modulefile to make the linter happy (don't delete)

--- a/autotools.sh
+++ b/autotools.sh
@@ -6,8 +6,8 @@ prefer_system: "(?!slc5|slc6)"
 prefer_system_check: |
   for bin in autoconf m4 automake makeinfo aclocal pkg-config autopoint libtool; do
     if ! command -v "$bin" >/dev/null 2>&1; then
-      cat <<\EOF
-  One or more autotools packages are missing on your system.
+      cat <<EOF
+  $bin is missing on your system.
    * On a RHEL-compatible system you probably need:
      autoconf automake texinfo gettext gettext-devel libtool
    * On an Ubuntu-like system you probably need:

--- a/autotools.sh
+++ b/autotools.sh
@@ -4,9 +4,16 @@ tag: v1.6.4
 source: https://github.com/alisw/autotools
 prefer_system: "(?!slc5|slc6)"
 prefer_system_check: |
-  export PATH=$PATH:$(brew --prefix gettext || true)/bin;
-  which autoconf && which m4 && which automake && which makeinfo && which aclocal && which pkg-config && which autopoint && which libtool;
-  if [ $? -ne 0 ]; then printf "One or more autotools packages are missing on your system.\n * On a RHEL-compatible system you probably need: autoconf automake texinfo gettext gettext-devel libtool\n * On an Ubuntu-like system you probably need: autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config\n * On macOS you need: brew install autoconf automake gettext pkg-config"; exit 1; fi
+  if ! (which autoconf && which m4 && which automake && which makeinfo && which aclocal && which pkg-config && which autopoint && which libtool); then
+    cat <<\EOF
+  One or more autotools packages are missing on your system.
+   * On a RHEL-compatible system you probably need:
+     autoconf automake texinfo gettext gettext-devel libtool
+   * On an Ubuntu-like system you probably need:
+     autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config
+  EOF
+    exit 1
+  fi
 prepend_path:
   PKG_CONFIG_PATH: $(pkg-config --debug 2>&1 | grep 'Scanning directory' | sed -e "s/.*'\(.*\)'/\1/" | xargs echo | sed -e 's/ /:/g')
 build_requires:
@@ -133,28 +140,21 @@ esac
 
 # pkgconfig -- requires: nothing special
 pushd pkg-config*
-  OLD_LDFLAGS="$LDFLAGS"
-  [[ ${ARCHITECTURE:0:3} == osx ]] && export LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Carbon"
   ./configure --disable-debug \
               --prefix=$INSTALLROOT \
               --disable-host-tool \
               --with-internal-glib
-  export LDFLAGS="$OLD_LDFLAGS"
   make ${JOBS+-j $JOBS}
   make install
   hash -r
 popd
 
-# We need to detect OSX becase xargs behaves differently there
-XARGS_DO_NOT_FAIL='-r'
-[[ ${ARCHITECTURE:0:3} == osx ]] && XARGS_DO_NOT_FAIL=
-
 # Fix perl location, required on /usr/bin/perl
 grep -l -R -e '^#!.*perl' $INSTALLROOT | \
-  xargs ${XARGS_DO_NOT_FAIL} -n1 sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/perl;'
+  xargs -r -n1 sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/perl;'
 find $INSTALLROOT -name '*deleteme' -delete
 grep -l -R -e 'exec [^ ]*/perl' $INSTALLROOT | \
-  xargs ${XARGS_DO_NOT_FAIL} -n1 sed -ideleteme -e 's;exec [^ ]*/perl;exec /usr/bin/perl;g'
+  xargs -r -n1 sed -ideleteme -e 's;exec [^ ]*/perl;exec /usr/bin/perl;g'
 find $INSTALLROOT -name '*deleteme' -delete
 
 # Pretend we have a modulefile to make the linter happy (don't delete)

--- a/boost.sh
+++ b/boost.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "v1.83.0"
 source: https://github.com/alisw/boost.git
 requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - Python
 build_requires:
   - lzma
@@ -17,8 +17,7 @@ prefer_system_check: |
 ---
 BOOST_PYTHON=
 BOOST_CXXFLAGS=
-if [[ $ARCHITECTURE != osx* && $PYTHON_MODULES_VERSION ]]; then
-  # Enable boost_python on platforms other than macOS
+if [[ $PYTHON_MODULES_VERSION ]]; then
   BOOST_PYTHON=1
   if [[ $PYTHON_VERSION ]]; then
     # Our Python. We need to pass the appropriate flags to boost for the includes
@@ -54,10 +53,7 @@ if [[ $CXXSTD && $CXXSTD -ge 17 ]]; then
 fi
 
 TMPB2=$BUILDDIR/tmp-boost-build
-case $ARCHITECTURE in
-  osx*) TOOLSET=clang-darwin ;;
-  *) TOOLSET=gcc ;;
-esac
+TOOLSET=gcc
 
 rsync -a $SOURCEDIR/ $BUILDDIR/
 cd $BUILDDIR/tools/build
@@ -66,10 +62,8 @@ cd $BUILDDIR/tools/build
 # This is causing havok on different combinations of Ubuntu / Anaconda
 # installations.
 bash bootstrap.sh $TOOLSET
-case $ARCHITECTURE in
-  osx*)  ;;
-  *) export CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:$(python3 -c 'import sysconfig; print(sysconfig.get_path("include"))')" ;;
-esac
+PYINCPATH=$(python3 -c 'import sysconfig; print(sysconfig.get_path("include"))')
+export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH:+$CPLUS_INCLUDE_PATH:}$PYINCPATH"
 mkdir -p $TMPB2
 ./b2 install --prefix=$TMPB2
 export PATH=$TMPB2/bin:$PATH
@@ -108,22 +102,9 @@ b2 -q                                            \
 # If boost_python is enabled, check if it was really compiled
 [[ $BOOST_PYTHON ]] && ls -1 "$INSTALLROOT"/lib/*boost_python* > /dev/null
 
-# We need to tell boost libraries linking other boost libraries to look for them
-# inside the same directory as the main ones, on macOS (@loader_path).
-if [[ $ARCHITECTURE == osx* ]]; then
-  for LIB in $INSTALLROOT/lib/libboost*.dylib; do
-    otool -L $LIB | grep -v $(basename $LIB) | { grep -oE 'libboost_[^ ]+' || true; } | \
-      xargs -I{} install_name_tool -change {} @loader_path/{} "$LIB"
-  done
-fi
-
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-
-mkdir -p etc/modulefiles
-alibuild-generate-module --bin --lib > etc/modulefiles/$PKGNAME
-cat << EOF >> etc/modulefiles/$PKGNAME
-prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
-EOF
-mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<\EoF
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
+EoF

--- a/cmake.sh
+++ b/cmake.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: "v4.2.3"
 source: https://github.com/Kitware/CMake
 build_requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |

--- a/cmake.sh
+++ b/cmake.sh
@@ -4,6 +4,7 @@ tag: "v4.2.3"
 source: https://github.com/Kitware/CMake
 build_requires:
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
     REQUESTED_VERSION=3.20.0
@@ -31,20 +32,6 @@ $SOURCEDIR/bootstrap --prefix=$INSTALLROOT \
 make ${JOBS+-j $JOBS}
 make install/strip
 
-mkdir -p etc/modulefiles
-cat >etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 \\
-       ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-setenv CMAKE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(CMAKE_ROOT)/bin
-EoF
-mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/eigen3.sh
+++ b/eigen3.sh
@@ -2,7 +2,7 @@ package: Eigen3
 version: 3.4.0
 source: https://gitlab.com/libeigen/eigen.git
 build_requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - CMake
   - alibuild-recipe-tools
 prefer_system_check: |

--- a/evtgen.sh
+++ b/evtgen.sh
@@ -14,6 +14,8 @@ prefer_system_check: |
         exit 0
     fi
     exit 1
+build_requires:
+  - alibuild-recipe-tools
 ---
 #!/bin/sh
 
@@ -35,22 +37,8 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
 make ${JOBS:+-j$JOBS} install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 pythia/$PYTHIA_VERSION-$PYTHIA_REVISION ${HEPMC3_VERSION:+HepMC3/$HEPMC3_VERSION-$HEPMC3_REVISION} ${TAUOLAPP_VERSION:+Tauolapp/$TAUOLAPP_VERSION-$TAUOLAPP_REVISION} ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}
-# Our environment
-setenv EVTGEN_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv EVTGENDATA \$::env(EVTGEN_ROOT)/share/EvtGen
-prepend-path LD_LIBRARY_PATH \$::env(EVTGEN_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(EVTGEN_ROOT)/lib")
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv EVTGENDATA \$PKG_ROOT/share/EvtGen
 EoF

--- a/faircmakemodules.sh
+++ b/faircmakemodules.sh
@@ -4,7 +4,7 @@ tag: v1.0.0
 source: https://github.com/FairRootGroup/FairCMakeModules
 build_requires:
   - CMake
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - alibuild-recipe-tools
 prefer_system_check: |
     if [ ! -z "$FAIRCMAKEMODULES_VERSION" ]; then

--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -6,7 +6,7 @@ requires:
  - fmt
 build_requires:
  - CMake
- - "GCC-Toolchain:(?!osx)"
+ - GCC-Toolchain
  - alibuild-recipe-tools
 incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
@@ -20,14 +20,6 @@ prefer_system_check: |
   verge $REQUESTED_VERSION $FAIRLOGGER_VERSION
 ---
 #!/bin/bash
-
-case $ARCHITECTURE in
-  osx*)
-    # If we preferred system tools, we need to make sure we can pick them up.
-    [[ ! $FMT_ROOT ]] && FMT_ROOT=`brew --prefix fmt`
-  ;;
-  *) ;;
-esac
 
 mkdir -p $INSTALLROOT
 
@@ -47,6 +39,6 @@ cmake --build . --target install ${JOBS:+-- -j$JOBS}
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
-cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
-prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<\EoF
+prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
 EoF

--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -7,6 +7,7 @@ requires:
 build_requires:
  - CMake
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
@@ -43,23 +44,9 @@ cmake --build . ${JOBS:+-- -j$JOBS}
 ctest ${JOBS:+-j$JOBS}
 cmake --build . --target install ${JOBS:+-- -j$JOBS}
 
-# ModuleFile
-mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                        \
-       ${FMT_REVISION:+fmt/${FMT_VERSION}-${FMT_REVISION}}
-# Our environment
-set FAIRLOGGER_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$FAIRLOGGER_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$FAIRLOGGER_ROOT/include
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-mkdir -p $MODULEDIR && rsync -a --delete etc/modulefiles/ $MODULEDIR

--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -10,7 +10,11 @@ build_requires:
  - alibuild-recipe-tools
 incremental_recipe: |
   cmake --build . --target install ${JOBS:+-- -j$JOBS}
-  mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+  mkdir -p "$INSTALLROOT/etc/modulefiles"
+  alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+  cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<\EoF
+  prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
+  EoF
 prepend_path:
   ROOT_INCLUDE_PATH: "$FAIRLOGGER_ROOT/include"
 prefer_system_check: |

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -80,6 +80,7 @@ mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 setenv FAIRROOT_HASH $FAIRROOT_HASH
+setenv FAIRROOTPATH \$PKG_ROOT
 setenv VMCWORKDIR \$PKG_ROOT/share/fairbase/examples
 setenv GEOMPATH \$::env(VMCWORKDIR)/common/geometry
 setenv CONFIG_DIR \$::env(VMCWORKDIR)/common/gconfig

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -15,7 +15,7 @@ requires:
   - FairLogger
   - yaml-cpp
   - GEANT3
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
 build_requires:
   - FairCMakeModules
   - alibuild-recipe-tools
@@ -38,22 +38,9 @@ prepend_path:
 # maximum safety.
 unset SIMPATH
 
-case $ARCHITECTURE in
-  osx*)
-    # If we preferred system tools, we need to make sure we can pick them up.
-    [[ ! $YAML_CPP_ROOT ]] && YAML_CPP_ROOT=`brew --prefix yaml-cpp`
-    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
-    [[ ! $GSL_ROOT ]] && GSL_ROOT=`brew --prefix gsl`
-    MACOSX_RPATH=OFF
-    SONAME=dylib
-  ;;
-  *) SONAME=so ;;
-esac
-
 [[ $BOOST_ROOT ]] && BOOST_NO_SYSTEM_PATHS=ON || BOOST_NO_SYSTEM_PATHS=OFF
 cmake $SOURCEDIR                                                                            \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                                             \
-      ${MACOSX_RPATH:+-DMACOSX_RPATH=${MACOSX_RPATH}}                                       \
       -DCMAKE_CXX_FLAGS="$CXXFLAGS"                                                         \
       -DCMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST                                   \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}                             \

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -18,6 +18,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - FairCMakeModules
+  - alibuild-recipe-tools
 env:
   VMCWORKDIR: "$FAIRROOT_ROOT/share/fairbase/examples"
   GEOMPATH:   "$FAIRROOT_ROOT/share/fairbase/examples/common/geometry"
@@ -88,39 +89,12 @@ FAIRROOT_HASH=$(git rev-parse HEAD)
 cd $BUILDDIR
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0                                                                            \\
-            ${YAML_CPP_REVISION:+yaml-cpp/$YAML_CPP_VERSION-$YAML_CPP_REVISION}                  \\
-            ${FAIRLOGGER_REVISION:+FairLogger/$FAIRLOGGER_VERSION-$FAIRLOGGER_REVISION}         \\
-            ${GEANT3_REVISION:+GEANT3/$GEANT3_VERSION-$GEANT3_REVISION}                         \\
-            ${GEANT4_VMC_REVISION:+GEANT4_VMC/$GEANT4_VMC_VERSION-$GEANT4_VMC_REVISION}         \\
-            ${PYTHIA6_REVISION:+pythia6/$PYTHIA6_VERSION-$PYTHIA6_REVISION}                     \\
-            ${PYTHIA_REVISION:+pythia/$PYTHIA_VERSION-$PYTHIA_REVISION}                         \\
-            ${VGM_REVISION:+vgm/$VGM_VERSION-$VGM_REVISION}                                     \\
-            ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}                             \\
-            ROOT/$ROOT_VERSION-$ROOT_REVISION                                                   \\
-            ${ZEROMQ_REVISION:+ZeroMQ/$ZEROMQ_VERSION-$ZEROMQ_REVISION}                         \\
-            ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set FAIRROOT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-set FAIRROOTPATH \$::env(BASEDIR)/$PKGNAME/\$version
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 setenv FAIRROOT_HASH $FAIRROOT_HASH
-setenv VMCWORKDIR \$FAIRROOT_ROOT/share/fairbase/examples
+setenv VMCWORKDIR \$PKG_ROOT/share/fairbase/examples
 setenv GEOMPATH \$::env(VMCWORKDIR)/common/geometry
 setenv CONFIG_DIR \$::env(VMCWORKDIR)/common/gconfig
-prepend-path PATH \$FAIRROOT_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$FAIRROOT_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$FAIRROOT_ROOT/include
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF

--- a/fmt.sh
+++ b/fmt.sh
@@ -6,6 +6,7 @@ requires:
   - "GCC-Toolchain:(?!osx)"
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 prepend_path:
   ROOT_INCLUDE_PATH: "$FMT_ROOT/include"
 prefer_system_check: |
@@ -22,20 +23,8 @@ make ${JOBS+-j $JOBS}
 make install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_REVISION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set FMT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path ROOT_INCLUDE_PATH \$FMT_ROOT/include
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF

--- a/fmt.sh
+++ b/fmt.sh
@@ -3,7 +3,7 @@ version: "%(tag_basename)s"
 tag: 11.2.0
 source: https://github.com/fmtlib/fmt
 requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
 build_requires:
   - CMake
   - alibuild-recipe-tools
@@ -24,7 +24,7 @@ make install
 
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"
-alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF

--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -23,10 +23,6 @@ echo "Building GCC because no compatible version was found on the system. To ski
 
 USE_GOLD=
 case $ARCHITECTURE in
-  osx*)
-    EXTRA_LANGS=',objc,obj-c++'
-    MARCH=
-  ;;
   *x86-64)
     MARCH='x86_64-unknown-linux-gnu'
   ;;

--- a/geant3.sh
+++ b/geant3.sh
@@ -43,5 +43,6 @@ alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 setenv GEANT3DIR \$PKG_ROOT
 setenv G3SYS \$PKG_ROOT
+prepend-path LD_LIBRARY_PATH \$PKG_ROOT/lib64
 prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include/TGeant3
 EoF

--- a/geant3.sh
+++ b/geant3.sh
@@ -7,6 +7,7 @@ requires:
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 source: https://github.com/vmc-project/geant3
 prepend_path:
   LD_LIBRARY_PATH: "$GEANT3_ROOT/lib64"
@@ -38,24 +39,10 @@ make ${JOBS:+-j $JOBS} install
 [[ ! -d $INSTALLROOT/lib64 ]] && ln -sf lib $INSTALLROOT/lib64
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION VMC/$VMC_VERSION-$VMC_REVISION
-# Our environment
-set GEANT3_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GEANT3_ROOT \$GEANT3_ROOT
-setenv GEANT3DIR \$GEANT3_ROOT
-setenv G3SYS \$GEANT3_ROOT
-prepend-path LD_LIBRARY_PATH \$GEANT3_ROOT/lib64
-prepend-path ROOT_INCLUDE_PATH \$GEANT3_ROOT/include/TGeant3
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv GEANT3DIR \$PKG_ROOT
+setenv G3SYS \$PKG_ROOT
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include/TGeant3
 EoF

--- a/geant3.sh
+++ b/geant3.sh
@@ -6,7 +6,6 @@ requires:
   - VMC
 build_requires:
   - CMake
-  - "Xcode:(osx.*)"
   - alibuild-recipe-tools
 source: https://github.com/vmc-project/geant3
 prepend_path:

--- a/geant4.sh
+++ b/geant4.sh
@@ -3,13 +3,12 @@ version: "%(tag_basename)s"
 tag: v11.4.0
 source: https://github.com/geant4/geant4.git
 requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - opengl
   - XercesC
 build_requires:
   - CMake
   - ninja
-  - "Xcode:(osx.*)"
   - alibuild-recipe-tools
 env:
   G4INSTALL: $GEANT4_ROOT

--- a/geant4.sh
+++ b/geant4.sh
@@ -84,6 +84,7 @@ G4SAIDXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT  '*data*G4SAIDDATA*'`
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv GEANT4_ROOT \$PKG_ROOT
 setenv G4INSTALL \$PKG_ROOT
 setenv G4INSTALL_DATA \$PKG_ROOT/share/
 set osname [uname sysname]

--- a/geant4.sh
+++ b/geant4.sh
@@ -10,6 +10,7 @@ build_requires:
   - CMake
   - ninja
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 env:
   G4INSTALL: $GEANT4_ROOT
   G4DATASEARCHOPT: "-mindepth 2 -maxdepth 4 -type d -wholename"
@@ -81,25 +82,12 @@ G4SAIDXSDATA=`find ${INSTALLROOT} $G4DATASEARCHOPT  '*data*G4SAIDDATA*'`
 
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${XERCESC_ROOT:+XercesC/$XERCESC_VERSION-$XERCESC_REVISION}
-# Our environment
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv G4INSTALL \$PKG_ROOT
+setenv G4INSTALL_DATA \$PKG_ROOT/share/
 set osname [uname sysname]
-set GEANT4_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GEANT4_ROOT \$GEANT4_ROOT
-setenv G4INSTALL \$GEANT4_ROOT
-setenv G4INSTALL_DATA \$GEANT4_ROOT/share/
 setenv G4SYSTEM \$osname-g++
 setenv G4ABLADATA ${G4ABLADATA:-not-defined}
 setenv G4ENSDFSTATEDATA ${G4ENSDFSTATEDATA:-not-defined}
@@ -110,13 +98,9 @@ setenv G4NEUTRONHPDATA ${G4NEUTRONHPDATA:-not-defined}
 setenv G4NEUTRONXSDATA ${G4NEUTRONXSDATA:-not-defined}
 setenv G4PARTICLEXSDATA ${G4PARTICLEXSDATA:-not-defined}
 setenv G4PIIDATA ${G4PIIDATA:-not-defined}
-setenv G4RADIOACTIVEDATA  ${G4RADIOACTIVEDATA:-not-defined}
+setenv G4RADIOACTIVEDATA ${G4RADIOACTIVEDATA:-not-defined}
 setenv G4REALSURFACEDATA ${G4REALSURFACEDATA:-not-defined}
 setenv G4SAIDXSDATA ${G4SAIDXSDATA:-not-defined}
-set G4BASE \$GEANT4_ROOT
-prepend-path PATH \$GEANT4_ROOT/bin
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include/Geant4
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_ROOT/include
-prepend-path LD_LIBRARY_PATH \$GEANT4_ROOT/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GEANT4_ROOT)/lib")
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include/Geant4
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -42,6 +42,7 @@ ln -nfs "$G4VMC_SHARE/examples" "$INSTALLROOT/share/examples"
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv GEANT4_VMC_ROOT \$PKG_ROOT
 setenv G4VMCINSTALL \$PKG_ROOT
 setenv GEANT4VMC_MACRO_DIR \$PKG_ROOT/share/examples/macro
 setenv USE_VGM 1

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -10,6 +10,7 @@ requires:
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
+  - alibuild-recipe-tools
 prepend_path:
   ROOT_INCLUDE_PATH: "$GEANT4_VMC_ROOT/include/g4root:$GEANT4_VMC_ROOT/include/geant4vmc:$GEANT4_VMC_ROOT/include/mtroot"
 env:
@@ -39,28 +40,13 @@ G4VMC_SHARE=$(cd "$INSTALLROOT/share"; echo Geant4VMC-* | cut -d' ' -f1)
 ln -nfs "$G4VMC_SHARE/examples" "$INSTALLROOT/share/examples"
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GEANT4_REVISION:+GEANT4/$GEANT4_VERSION-$GEANT4_REVISION} ${ROOT_REVISION:+ROOT/$ROOT_VERSION-$ROOT_REVISION} ${VMC_REVISION:+VMC/$VMC_VERSION-$VMC_REVISION} vgm/$VGM_VERSION-$VGM_REVISION
-# Our environment
-set GEANT4_VMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GEANT4_VMC_ROOT \$GEANT4_VMC_ROOT
-setenv G4VMCINSTALL \$GEANT4_VMC_ROOT
-setenv GEANT4VMC_MACRO_DIR \$GEANT4_VMC_ROOT/share/examples/macro
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv G4VMCINSTALL \$PKG_ROOT
+setenv GEANT4VMC_MACRO_DIR \$PKG_ROOT/share/examples/macro
 setenv USE_VGM 1
-prepend-path PATH \$GEANT4_VMC_ROOT/bin
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/mtroot
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/geant4vmc
-prepend-path ROOT_INCLUDE_PATH \$GEANT4_VMC_ROOT/include/g4root
-prepend-path LD_LIBRARY_PATH \$GEANT4_VMC_ROOT/lib
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include/mtroot
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include/geant4vmc
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include/g4root
 EoF

--- a/geant4_vmc.sh
+++ b/geant4_vmc.sh
@@ -9,7 +9,6 @@ requires:
   - vgm
 build_requires:
   - CMake
-  - "Xcode:(osx.*)"
   - alibuild-recipe-tools
 prepend_path:
   ROOT_INCLUDE_PATH: "$GEANT4_VMC_ROOT/include/g4root:$GEANT4_VMC_ROOT/include/geant4vmc:$GEANT4_VMC_ROOT/include/mtroot"

--- a/genfit.sh
+++ b/genfit.sh
@@ -7,7 +7,7 @@ requires:
   - boost
 build_requires:
   - CMake
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - alibuild-recipe-tools
 env:
   GENFIT: "$GENFIT_ROOT"
@@ -30,7 +30,6 @@ sed -i 's|\${CMAKE_CURRENT_SOURCE_DIR}/[^/]*/include/||g' "$SOURCEDIR/CMakeLists
 : ${BUILD_TESTING:=OFF}
 cmake $SOURCEDIR                                                                            \
       ${CMAKE_GENERATOR:+-G "$CMAKE_GENERATOR"}                                             \
-      ${MACOSX_RPATH:+-DMACOSX_RPATH=${MACOSX_RPATH}}                                       \
       -DCMAKE_CXX_FLAGS="$CXXFLAGS"                                                         \
       ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE}                             \
       -DGTEST_ROOT=$GOOGLETEST_ROOT \

--- a/genfit.sh
+++ b/genfit.sh
@@ -8,6 +8,7 @@ requires:
 build_requires:
   - CMake
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 env:
   GENFIT: "$GENFIT_ROOT"
 prepend_path:
@@ -46,29 +47,9 @@ cmake $SOURCEDIR                                                                
 cmake --build . -- -j$JOBS install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-
-
-cat >> "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-if ![ is-loaded 'BASE/1.0' ] {
- module load BASE/1.0
-}
-
-set PKG_ROOT $::env(BASEDIR)/GenFit/\$version
-
-# Our environment
-set GENFIT_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GENFIT \$GENFIT_ROOT
-prepend-path LD_LIBRARY_PATH \$GENFIT_ROOT/lib
-prepend-path ROOT_INCLUDE_PATH \$GENFIT_ROOT/include
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv GENFIT \$PKG_ROOT
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/include
 EoF

--- a/genie.sh
+++ b/genie.sh
@@ -26,6 +26,8 @@ prefer_system_check: |
   ls $GENIE_ROOT/genie/lib > /dev/null && \
   ls $GENIE_ROOT/genie/src > /dev/null && \
   true
+build_requires:
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -ex
 export GENIE="$BUILDDIR"
@@ -79,25 +81,12 @@ rsync -a src/*/*/*.h $INSTALLROOT/genie/inc
 #cp $INSTALLROOT/genie/data/evgen/pdfs/GRV98lo_patched.LHgrid $LHAPDF5_ROOT/share/lhapdf
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION pythia/$PYTHIA_VERSION-$PYTHIA_REVISION lhapdf/$LHAPDF_VERSION-$LHAPDF_REVISION log4cpp/$LOG4CPP_VERSION-$LOG4CPP_REVISION ${LIBXML2:+libxml2/$LIBXML2_VERSION-$LIBXML2_REVISION} ${GSL_VERSION:+GSL/$GSL_VERSION-$GSL_REVISION} apfel/$APFEL_VERSION-$APFEL_REVISION
-# Our environment
-setenv GENIE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv GENIE \$::env(GENIE_ROOT)/genie
-prepend-path LD_LIBRARY_PATH \$::env(GENIE_ROOT)/genie/lib
-prepend-path ROOT_INCLUDE_PATH \$::env(GENIE_ROOT)/genie/inc
-prepend-path ROOT_INCLUDE_PATH \$::env(GENIE_ROOT)/genie/src
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(GENIE_ROOT)/lib")
-append-path PATH \$::env(GENIE_ROOT)/genie/bin
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv GENIE \$PKG_ROOT/genie
+prepend-path LD_LIBRARY_PATH \$PKG_ROOT/genie/lib
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/genie/inc
+prepend-path ROOT_INCLUDE_PATH \$PKG_ROOT/genie/src
+append-path PATH \$PKG_ROOT/genie/bin
 EoF

--- a/genie.sh
+++ b/genie.sh
@@ -82,7 +82,7 @@ rsync -a src/*/*/*.h $INSTALLROOT/genie/inc
 
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"
-alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 setenv GENIE \$PKG_ROOT/genie
 prepend-path LD_LIBRARY_PATH \$PKG_ROOT/genie/lib

--- a/googletest.sh
+++ b/googletest.sh
@@ -3,8 +3,8 @@ version: "1.17.0"
 source: https://github.com/google/googletest
 tag: v1.17.0
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - CMake
+  - GCC-Toolchain
+  - CMake
 prefer_system_check: |
   #!/bin/bash -e
   ls $GOOGLETEST_ROOT/ > /dev/null && \

--- a/gsl.sh
+++ b/gsl.sh
@@ -3,13 +3,13 @@ version: "v2.8"
 tag: "v2.8"
 source: https://github.com/alisw/gsl
 requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
 build_requires:
   - "autotools:(slc6|slc7)"
   - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | cc -xc - -I$(brew --prefix gsl)/include  -c -o /dev/null
+  printf "#include \"gsl/gsl_version.h\"\n#define GSL_V GSL_MAJOR_VERSION * 100 + GSL_MINOR_VERSION\n# if (GSL_V < 116)\n#error \"Cannot use system's gsl. Notice we only support versions from 1.16 (included)\"\n#endif\nint main(){}" | cc -xc - ${GSL_ROOT:+-I$GSL_ROOT/include} -c -o /dev/null
 ---
 #!/bin/bash -e
 rsync -a --chmod=ug=rwX --exclude .git --delete-excluded $SOURCEDIR/ $BUILDDIR/

--- a/hepmc.sh
+++ b/hepmc.sh
@@ -5,6 +5,7 @@ tag: alice/v2.06.09
 build_requires:
   - CMake
   - GCC-Toolchain:(?!osx.*)
+  - alibuild-recipe-tools
 prefer_system_check: |
   #!/bin/bash -e
   ls $HEPMC_ROOT/lib > /dev/null && \
@@ -32,22 +33,5 @@ make ${JOBS+-j $JOBS}
 make install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-setenv HEPMC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(HEPMC_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(HEPMC_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(HEPMC_ROOT)/lib")
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/hepmc.sh
+++ b/hepmc.sh
@@ -4,7 +4,7 @@ source: https://github.com/alisw/hepmc
 tag: alice/v2.06.09
 build_requires:
   - CMake
-  - GCC-Toolchain:(?!osx.*)
+  - GCC-Toolchain
   - alibuild-recipe-tools
 prefer_system_check: |
   #!/bin/bash -e

--- a/hepmc3.sh
+++ b/hepmc3.sh
@@ -6,7 +6,7 @@ requires:
   - ROOT
 build_requires:
   - CMake
-  - GCC-Toolchain:(?!osx.*)
+  - GCC-Toolchain
   - alibuild-recipe-tools
 env:
   "HEPMC3": "$HEPMC3_ROOT"

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -8,6 +8,7 @@ requires:
  - "GCC-Toolchain:(?!osx)"
 build_requires:
  - autotools
+ - alibuild-recipe-tools
 env:
   LHAPATH: "$LHAPDF_ROOT/share/LHAPDF"
 prefer_system_check: |
@@ -47,22 +48,8 @@ for P in $PDFSETS; do
 done
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-# Our environment
-setenv LHAPDF_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv LHAPATH \$::env(LHAPDF_ROOT)/share/LHAPDF
-prepend-path PATH $::env(LHAPDF_ROOT)/bin
-prepend-path LD_LIBRARY_PATH $::env(LHAPDF_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(LHAPDF_ROOT)/lib")
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv LHAPATH \$PKG_ROOT/share/LHAPDF
 EoF

--- a/lhapdf.sh
+++ b/lhapdf.sh
@@ -5,7 +5,7 @@ source:  https://gitlab.com/hepcedar/lhapdf
 requires:
  - "Python:slc.*"
  - "Python-system:(?!slc.*)"
- - "GCC-Toolchain:(?!osx)"
+ - GCC-Toolchain
 build_requires:
  - autotools
  - alibuild-recipe-tools
@@ -21,16 +21,6 @@ prefer_system_check: |
   ls $LHAPDF_ROOT/share/LHAPDF > /dev/null
 ---
 #!/bin/bash -ex
-case $ARCHITECTURE in
-  osx*)
-    # If we preferred system tools, we need to make sure we can pick them up.
-    [[ ! $AUTOTOOLS_ROOT ]] && PATH=$PATH:$(brew --prefix gettext)/bin
-  ;;
-  *)
-    EXTRA_LD_FLAGS="-Wl,--no-as-needed"
-  ;;
-esac
-
 rsync -a --exclude '**/.git' "$SOURCEDIR"/ ./
 
 autoreconf -ivf

--- a/libffi.sh
+++ b/libffi.sh
@@ -2,6 +2,7 @@ package: libffi
 version: v3.2.1
 build_requires:
  - autotools
+ - alibuild-recipe-tools
 source: https://github.com/libffi/libffi
 prepend_path:
   LD_LIBRARY_PATH: "$LIBFFI_ROOT/lib64"
@@ -13,21 +14,8 @@ autoreconf -ivf .
 make ${JOBS:+-j $JOBS}
 make install
 
-LIBPATH=$(find $INSTALLROOT -name libffi.so)
+[[ -d $INSTALLROOT/lib64 && ! -d $INSTALLROOT/lib ]] && ln -nfs lib64 $INSTALLROOT/lib
+
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/$(basename $(dirname $LIBPATH))
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/libffi.sh
+++ b/libffi.sh
@@ -19,3 +19,6 @@ make install
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+prepend-path LD_LIBRARY_PATH \$PKG_ROOT/lib64
+EoF

--- a/libxml2.sh
+++ b/libxml2.sh
@@ -5,6 +5,7 @@ build_requires:
   - "autotools:(slc6|slc7)"
   - zlib
   - "GCC-Toolchain:(?!osx)"
+  - alibuild-recipe-tools
 source: https://github.com/alisw/libxml2.git
 prefer_system: "(?!slc5)"
 prefer_system_check: |
@@ -22,22 +23,5 @@ autoreconf -i
 make ${JOBS+-j $JOBS}
 make install
 # Modulefile
-mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${ZLIB_REVISION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}
-# Our environment
-setenv LIBXML2_VERSION \$version
-set LIBXML2_ROOT \$::env(BASEDIR)/$PKGNAME/\$::env(LIBXML2_VERSION)
-setenv LIBXML2_ROOT \$LIBXML2_ROOT
-prepend-path PATH \$LIBXML2_ROOT/bin
-prepend-path LD_LIBRARY_PATH \$LIBXML2_ROOT/lib
-EoF
-mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/libxml2.sh
+++ b/libxml2.sh
@@ -4,7 +4,7 @@ tag: v2.9.3
 build_requires:
   - "autotools:(slc6|slc7)"
   - zlib
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - alibuild-recipe-tools
 source: https://github.com/alisw/libxml2.git
 prefer_system: "(?!slc5)"

--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -2,7 +2,7 @@ package: log4cpp
 source: https://git.code.sf.net/p/log4cpp/codegit
 version: 1b9f8f7c031d6947c7468d54bc1da4b2f414558d
 requires:
-  - GCC-Toolchain:(?!osx)
+  - GCC-Toolchain
 build_requires:
   - autotools
   - alibuild-recipe-tools

--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -5,6 +5,7 @@ requires:
   - GCC-Toolchain:(?!osx)
 build_requires:
   - autotools
+  - alibuild-recipe-tools
 env:
   LOG4_ROOT: "$LOG4CPP_ROOT"
 prefer_system_check: |
@@ -20,22 +21,6 @@ rsync -a $SOURCEDIR/* .
 make ${JOBS+-j$JOBS}
 make install
 
-# Modulefile support
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-setenv LOG4CPP_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(LOG4CPP_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(LOG4CPP_ROOT)/lib
-EoF
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/lzma.sh
+++ b/lzma.sh
@@ -4,8 +4,9 @@ tag: "v5.2.3"
 source: https://github.com/alisw/liblzma
 build_requires:
   - autotools
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - rsync
+  - alibuild-recipe-tools
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <lzma.h>\n" | c++ -xc++ - -c -M 2>&1
@@ -24,23 +25,5 @@ make ${JOBS+-j $JOBS} install
 rm -f "$INSTALLROOT"/lib/*.la
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-set LZMA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv LZMA_ROOT \$LZMA_ROOT
-set BASEDIR \$::env(BASEDIR)
-prepend-path LD_LIBRARY_PATH \$BASEDIR/$PKGNAME/\$version/lib
-prepend-path PATH \$BASEDIR/$PKGNAME/\$version/bin
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/ninja.sh
+++ b/ninja.sh
@@ -3,7 +3,7 @@ version: "fortran-%(short_hash)s"
 tag: "v1.11.1.g95dee.kitware.jobserver-1"
 source: https://github.com/Kitware/ninja
 build_requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - "CMake"
   - alibuild-recipe-tools
 prefer_system: .*

--- a/npdb-client.sh
+++ b/npdb-client.sh
@@ -3,7 +3,7 @@ version: "0.2.0"
 tag: "0.2.0"
 source: https://gitlab.cern.ch/ship/computing/npdb
 build_requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - CMake
   - rust
   - alibuild-recipe-tools

--- a/opengl.sh
+++ b/opengl.sh
@@ -7,9 +7,5 @@ system_requirement_missing: |
 system_requirement: ".*"
 system_requirement_check: |
 
-  if [ $(uname) = Darwin ]; then
-   printf "#include <OpenGL/glu.h>\n" | cc -xc - -c -o /dev/null
-  else
-   printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null
-  fi
+  printf "#include <GL/glu.h>\n" | cc -xc - -c -o /dev/null
 ---

--- a/openssl.sh
+++ b/openssl.sh
@@ -5,11 +5,7 @@ source: https://github.com/openssl/openssl
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
   #!/bin/bash -e
-  case $(uname) in
-    Darwin) prefix=$(brew --prefix openssl@3); [ -d "$prefix" ] ;;
-    *) prefix= ;;
-  esac
-  cc -x c - ${prefix:+"-I$prefix/include"} -c -o /dev/null <<\EOF
+  cc -x c - -c -o /dev/null <<\EOF
   #include <openssl/bio.h>
   #include <openssl/opensslv.h>
   #if OPENSSL_VERSION_NUMBER < 0x10101000L
@@ -20,7 +16,7 @@ prefer_system_check: |
 build_requires:
   - zlib
   - alibuild-recipe-tools
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
 prepend_path:
   PKG_CONFIG_PATH: "$OPENSSL_ROOT/lib/pkgconfig"
 ---

--- a/pcre.sh
+++ b/pcre.sh
@@ -4,7 +4,7 @@ source: https://github.com/ktf/pcre
 tag: master
 prefer_system: (?!slc5)
 prefer_system_check: |
-  printf "#include \"pcre.h\"\n" | gcc -I`brew --prefix pcre`/include -xc++ - -c -o /dev/null
+  printf "#include \"pcre.h\"\n" | gcc -xc++ - -c -o /dev/null
 ---
 #!/bin/sh
 echo "Building our own pcre. If you want to avoid this, please install pcre development package."

--- a/pythia.sh
+++ b/pythia.sh
@@ -40,6 +40,7 @@ chmod a+x $INSTALLROOT/bin/pythia8-config
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv PYTHIA_ROOT \$PKG_ROOT
 setenv PYTHIA8DATA \$PKG_ROOT/share/Pythia8/xmldoc
 setenv PYTHIA8 \$PKG_ROOT
 EoF

--- a/pythia.sh
+++ b/pythia.sh
@@ -25,12 +25,6 @@ build_requires:
 ---
 #!/bin/bash -e
 rsync -a $SOURCEDIR/ ./
-case $ARCHITECTURE in
-  osx*)
-    # If we preferred system tools, we need to make sure we can pick them up.
-    [[ ! $BOOST_ROOT ]] && BOOST_ROOT=`brew --prefix boost`
-  ;;
-esac
 
 ./configure --prefix=$INSTALLROOT \
             --enable-shared \

--- a/pythia.sh
+++ b/pythia.sh
@@ -20,6 +20,8 @@ prefer_system_check: |
   ls $PYTHIA_ROOT/lib/libpythia8lhapdf6.so > /dev/null && \
   ls $PYTHIA_ROOT/lib/libpythia8.so > /dev/null && \
   true
+build_requires:
+  - alibuild-recipe-tools
 ---
 #!/bin/bash -e
 rsync -a $SOURCEDIR/ ./
@@ -41,24 +43,9 @@ make install
 chmod a+x $INSTALLROOT/bin/pythia8-config
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${LHAPDF_VERSION:+lhapdf/$LHAPDF_VERSION-$LHAPDF_REVISION} ${BOOST_VERSION:+boost/$BOOST_VERSION-$BOOST_REVISION} HepMC/$HEPMC_VERSION-$HEPMC_REVISION
-# Our environment
-setenv PYTHIA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv PYTHIA8DATA \$::env(PYTHIA_ROOT)/share/Pythia8/xmldoc
-setenv PYTHIA8 \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PATH \$::env(PYTHIA_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(PYTHIA_ROOT)/lib")
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv PYTHIA8DATA \$PKG_ROOT/share/Pythia8/xmldoc
+setenv PYTHIA8 \$PKG_ROOT
 EoF

--- a/pythia6.sh
+++ b/pythia6.sh
@@ -29,5 +29,6 @@ mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 setenv PYTHIA6 \$PKG_ROOT
+setenv PYTHIA6_ROOT \$PKG_ROOT
 prepend-path AGILE_GEN_PATH \$PKG_ROOT
 EoF

--- a/pythia6.sh
+++ b/pythia6.sh
@@ -10,6 +10,7 @@ prefer_system_check: |
   ls $PYTHIA6_ROOT/lib/libPythia6.so > /dev/null
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 ---
 #!/bin/sh
 
@@ -24,23 +25,9 @@ make install
 cp $INSTALLROOT/lib/libpythia6.so $INSTALLROOT/lib/libPythia6.so
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-setenv PYTHIA6_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv PYTHIA6 \$::env(PYTHIA6_ROOT)
-prepend-path LD_LIBRARY_PATH \$::env(PYTHIA6_ROOT)/lib
-prepend-path AGILE_GEN_PATH \$::env(PYTHIA6_ROOT)
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(PYTHIA6_ROOT)/lib")
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv PYTHIA6 \$PKG_ROOT
+prepend-path AGILE_GEN_PATH \$PKG_ROOT
 EoF

--- a/pythia6.sh
+++ b/pythia6.sh
@@ -4,7 +4,7 @@ version: "%(tag_basename)s"
 tag: v6.4.28-snd
 source: https://github.com/SND-LHC/pythia6
 requires:
-  - GCC-Toolchain:(?!osx)
+  - GCC-Toolchain
 prefer_system_check: |
   ls $PYTHIA6_ROOT/lib/libpythia6.so > /dev/null && \
   ls $PYTHIA6_ROOT/lib/libPythia6.so > /dev/null

--- a/python-matplotlib.sh
+++ b/python-matplotlib.sh
@@ -5,7 +5,7 @@ source: https://github.com/matplotlib/matplotlib
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
-  - "FreeType:(?!osx)"
+  - FreeType
   - libpng
   - python-numpy
   - python-contourpy

--- a/python-pillow.sh
+++ b/python-pillow.sh
@@ -5,7 +5,7 @@ source: https://github.com/python-pillow/Pillow
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
-  - "FreeType:(?!osx)"
+  - FreeType
   - libpng
 build_requires:
   - uv

--- a/python-system.sh
+++ b/python-system.sh
@@ -4,7 +4,6 @@ system_requirement_missing: |
   Python 3.6 is missing from your system. We need the python3 and pip3 executables in the PATH.
   It can be installed with:
    * On Ubuntu: sudo apt-get install python3 python3-pip python3-tk
-   * On macOS: brew install python3
 system_requirement: ".*"
 system_requirement_check: |
   python3 -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (3,5) else 0)'

--- a/python.sh
+++ b/python.sh
@@ -6,7 +6,7 @@ requires:
   - FreeType
   - libpng
   - sqlite
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - libffi
 build_requires:
   - curl
@@ -20,11 +20,6 @@ prefer_system_check: |
     python3 -c 'from sys import version_info; print(f"alibuild_system_replace: python{version_info.major}.{version_info.minor}")'
     python3 -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (3, 12, 12) or sys.version_info > (3, 15) else 0)' && python3 -m pip --help > /dev/null && printf '#include "pyconfig.h"' | cc -c $(python3-config --includes) -xc -o /dev/null -; if [ $? -ne 0 ]; then printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n"; exit 1; fi
 prefer_system_replacement_specs:
-  "python-brew3.*":
-    version: "%(key)s"
-    env:
-        PYTHON_ROOT: $(brew --prefix python3)
-        PYTHON_REVISION: ""
   "python3.*":
     version: "%(key)s"
     env:

--- a/root.sh
+++ b/root.sh
@@ -21,6 +21,7 @@ build_requires:
 - libxml2
 - Python
 - ninja
+- alibuild-recipe-tools
 env:
   ROOTSYS: "$ROOT_ROOT"
 prepend_path:
@@ -125,30 +126,11 @@ cmake --build . ${JOBS+-j$JOBS} --target install
 [[ -d $INSTALLROOT/test ]] && ( cd $INSTALLROOT/test && env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH make ${JOBS+-j$JOBS} )
 
 # Modulefile
-mkdir -p etc/modulefiles
-cat > etc/modulefiles/$PKGNAME <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_VERSION:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}     \\
-                     ${GSL_VERSION:+GSL/$GSL_VERSION-$GSL_REVISION}                                             \\
-                     ${XROOTD_VERSION:+XRootD/$XROOTD_VERSION-$XROOTD_REVISION}                                 \\
-                     ${FREETYPE_VERSION:+FreeType/$FREETYPE_VERSION-$FREETYPE_REVISION}                         \\
-                     ${PYTHON_VERSION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}                                 \\
-                     ${PYTHON_NUMPY_VERSION:+python-numpy/$PYTHON_NUMPY_VERSION-$PYTHON_NUMPY_REVISION} \\
-                     ${PYTHIA_VERSION:+pythia/$PYTHIA_VERSION-$PYTHIA_REVISION}
-# Our environment
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 setenv ROOT_RELEASE \$version
-setenv ROOT_BASEDIR \$::env(BASEDIR)/$PKGNAME
-setenv ROOTSYS \$::env(ROOT_BASEDIR)/\$::env(ROOT_RELEASE)
-prepend-path PYTHONPATH \$::env(ROOTSYS)/lib
-prepend-path PATH \$::env(ROOTSYS)/bin
-prepend-path LD_LIBRARY_PATH \$::env(ROOTSYS)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(ROOTSYS)/lib")
+setenv ROOT_BASEDIR \$::env(BASEDIR)/ROOT
+setenv ROOTSYS \$PKG_ROOT
+prepend-path PYTHONPATH \$PKG_ROOT/lib
 EoF
-mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles

--- a/root.sh
+++ b/root.sh
@@ -4,20 +4,18 @@ tag: v6-36-08
 source: https://github.com/root-project/root
 requires:
 - GSL
-- opengl:(?!osx)
-- Xdevel:(?!osx)
-- FreeType:(?!osx)
+- opengl
+- Xdevel
+- FreeType
 - python-numpy
 - zlib
 - libxml2
-- "OpenSSL:(?!osx)"
-- "osx-system-openssl:(osx.*)"
+- OpenSSL
 - XRootD
 - pythia
 - TBB
 build_requires:
 - CMake
-- "Xcode:(osx.*)"
 - libxml2
 - Python
 - ninja
@@ -56,7 +54,7 @@ incremental_recipe: |
   make ${JOBS:+-j$JOBS} install
   mkdir -p $INSTALLROOT/etc/modulefiles && rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
   cd $INSTALLROOT/test
-  env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH make ${JOBS+-j$JOBS}
+  env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH make ${JOBS+-j$JOBS}
 ---
 #!/bin/bash -e
 unset ROOTSYS
@@ -69,17 +67,6 @@ COMPILER_LD=c++
 [[ "$CXXFLAGS" == *'-std=c++14'* ]] && CMAKE_CXX_STANDARD=14 || true
 [[ "$CXXFLAGS" == *'-std=c++17'* ]] && CMAKE_CXX_STANDARD=17 || true
 
-case $ARCHITECTURE in
-  osx*)
-    ENABLE_COCOA=1
-    COMPILER_CC=clang
-    COMPILER_CXX=clang++
-    COMPILER_LD=clang
-    [[ ! $GSL_ROOT ]] && GSL_ROOT=`brew --prefix gsl`
-    [[ ! $OPENSSL_ROOT ]] && SYS_OPENSSL_ROOT=`brew --prefix openssl`
-  ;;
-esac
-
 # Normal ROOT build.
 cmake $SOURCEDIR \
 -G Ninja \
@@ -89,13 +76,10 @@ ${XROOTD_ROOT:+-DXROOTD_ROOT_DIR=$XROOTD_ROOT}            \
 -DCMAKE_CXX_STANDARD=$CMAKE_CXX_STANDARD                  \
 -Dbuiltin_freetype=OFF                                    \
 -Dbuiltin_pcre=ON                                         \
-${ENABLE_COCOA:+-Dcocoa=ON}                               \
 -DCMAKE_CXX_COMPILER=$COMPILER_CXX                        \
 -DCMAKE_C_COMPILER=$COMPILER_CC                           \
 -DCMAKE_LINKER=$COMPILER_LD                               \
 ${GCC_TOOLCHAIN_VERSION:+-DCMAKE_EXE_LINKER_FLAGS="-L$GCC_TOOLCHAIN_ROOT/lib64"} \
-${SYS_OPENSSL_ROOT:+-DOPENSSL_ROOT=$SYS_OPENSSL_ROOT}     \
-${SYS_OPENSSL_ROOT:+-DOPENSSL_INCLUDE_DIR=$SYS_OPENSSL_ROOT/include} \
 ${GSL_ROOT:+-DGSL_DIR=$GSL_ROOT}                          \
 ${PYTHIA_ROOT:+-DPYTHIA8_DIR=$PYTHIA_ROOT}                \
 ${PYTHIA_ROOT:+-Dpythia8=ON}                \
@@ -107,10 +91,9 @@ ${PYTHIA_ROOT:+-Dpythia8=ON}                \
 -Ddavix=OFF                                                                      \
 ${PYTHON_ROOT:+-DPYTHON_EXECUTABLE=$PYTHONHOME/bin/python3} \
 ${PYTHON_ROOT:+-DPython3_ROOT_DIR=$PYTHON_ROOT} \
--DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$PYTHON_ROOT"
+-DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$GSL_ROOT;$PYTHON_ROOT"
 FEATURES="builtin_pcre xml ssl opengl http gdml mathmore ${PYTHIA_ROOT:+pythia8}
-    roofit soversion vdt ${XROOTD_ROOT:+xrootd}
-    ${ENABLE_COCOA:+builtin_freetype}"
+    roofit soversion vdt ${XROOTD_ROOT:+xrootd}"
 NO_FEATURES="${FREETYPE_ROOT:+builtin_freetype}"
 
 # Check if all required features are enabled
@@ -123,7 +106,7 @@ for FEATURE in $NO_FEATURES; do
 done
 
 cmake --build . ${JOBS+-j$JOBS} --target install
-[[ -d $INSTALLROOT/test ]] && ( cd $INSTALLROOT/test && env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH make ${JOBS+-j$JOBS} )
+[[ -d $INSTALLROOT/test ]] && ( cd $INSTALLROOT/test && env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH make ${JOBS+-j$JOBS} )
 
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"

--- a/rootegpythia6.sh
+++ b/rootegpythia6.sh
@@ -4,7 +4,7 @@ tag: main
 source: https://github.com/luketpickering/ROOTEGPythia6
 requires:
   - ROOT
-  - GCC-Toolchain:(?!osx)
+  - GCC-Toolchain
 build_requires:
   - CMake
 env:

--- a/sqlite.sh
+++ b/sqlite.sh
@@ -37,5 +37,4 @@ module load BASE/1.0
 setenv SQLITE_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path PATH $::env(SQLITE_ROOT)/bin
 prepend-path LD_LIBRARY_PATH $::env(SQLITE_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH $::env(SQLITE_ROOT)/lib")
 EoF

--- a/swig.sh
+++ b/swig.sh
@@ -4,7 +4,7 @@ source: https://github.com/swig/swig
 tag: rel-3.0.7
 build_requires:
   - autotools
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - yacc-like
 env:
   SWIG_LIB: "$SWIG_ROOT/share/swig/$SWIG_VERSION"

--- a/tauolapp.sh
+++ b/tauolapp.sh
@@ -40,7 +40,6 @@ module load BASE/1.0 ROOT/$ROOT_VERSION-$ROOT_REVISION pythia/$PYTHIA_VERSION-$P
 # Our environment
 setenv TAUOLA_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(TAUOLA_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(TAUOLA_ROOT)/lib")
 EoF
 
 cat $MODULEFILE

--- a/tbb.sh
+++ b/tbb.sh
@@ -3,14 +3,13 @@ version: "v2021.5.0"
 tag: v2021.5.0
 source: https://github.com/uxlfoundation/oneTBB
 build_requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - CMake
   - alibuild-recipe-tools
 prefer_system: .*
 prefer_system_check: |
   #!/bin/bash -e
   c++ -std=c++20 -xc++ - \
-     -I"$(brew --prefix tbb)"/include \
      -c -o /dev/null << 'EOF'
   #include <tbb/concurrent_unordered_map.h>
   static_assert(TBB_INTERFACE_VERSION >= 11009, "min version check failed");

--- a/uuid.sh
+++ b/uuid.sh
@@ -3,26 +3,17 @@ version: v2.27.1
 tag: alice/v2.27.1
 source: https://github.com/alisw/uuid
 build_requires:
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - "autotools:(slc6|slc7)"
 prepend_path:
   PKG_CONFIG_PATH: "$UUID_ROOT/share/pkgconfig"
 ---
 rsync -av --delete --exclude '**/.git' "$SOURCEDIR/" .
-if [[ $AUTOTOOLS_ROOT == "" ]]  && which brew >/dev/null; then
-  PATH=$PATH:$(brew --prefix gettext)/bin
-fi
 
 perl -p -i -e 's/AM_GNU_GETTEXT_VERSION\(\[0\.18\.3\]\)/AM_GNU_GETTEXT_VERSION([0.18.2])/' configure.ac
 
-case $ARCHITECTURE in
-  osx_*) disable_shared=yes ;;
-  *) disable_shared= ;;
-esac
-
 autoreconf -ivf
-# --disable-nls so we don't depend on gettext/libintl at runtime on Intel Macs.
-./configure ${disable_shared:+--disable-shared}   \
+./configure \
             "--libdir=$INSTALLROOT/lib"           \
             "--prefix=$INSTALLROOT"               \
             --disable-all-programs                \
@@ -36,7 +27,5 @@ make ${JOBS:+-j$JOBS} libuuid.la libuuid/uuid.pc install-uuidincHEADERS
 mkdir -p "$INSTALLROOT/lib" "$INSTALLROOT/share/pkgconfig"
 cp -a libuuid/uuid.pc "$INSTALLROOT/share/pkgconfig"
 cp -a .libs/libuuid.a* "$INSTALLROOT/lib"
-if [ -z "$disable_shared" ]; then
-  cp -a .libs/libuuid.so* "$INSTALLROOT/lib"
-fi
+cp -a .libs/libuuid.so* "$INSTALLROOT/lib"
 rm -rf "$INSTALLROOT/man"

--- a/uv.sh
+++ b/uv.sh
@@ -11,8 +11,6 @@ prefer_system_check: |
 case $(uname -sm) in
   "Linux x86_64")  UV_PLATFORM="x86_64-unknown-linux-gnu" ;;
   "Linux aarch64") UV_PLATFORM="aarch64-unknown-linux-gnu" ;;
-  "Darwin x86_64") UV_PLATFORM="x86_64-apple-darwin" ;;
-  "Darwin arm64")  UV_PLATFORM="aarch64-apple-darwin" ;;
   *) echo "Unsupported platform: $(uname -sm)" >&2; exit 1 ;;
 esac
 

--- a/vgm.sh
+++ b/vgm.sh
@@ -56,5 +56,4 @@ module load BASE/1.0 GEANT4/$GEANT4_VERSION-$GEANT4_REVISION ROOT/$ROOT_VERSION-
 # Our environment
 setenv VGM_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
 prepend-path LD_LIBRARY_PATH \$::env(VGM_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(VGM_ROOT)/lib")
 EoF

--- a/vmc.sh
+++ b/vmc.sh
@@ -6,7 +6,6 @@ requires:
   - ROOT
 build_requires:
   - CMake
-  - "Xcode:(osx.*)"
   - alibuild-recipe-tools
 prepend_path:
   ROOT_INCLUDE_PATH: "$VMC_ROOT/include/vmc"
@@ -33,14 +32,7 @@ cmake --build . -- ${JOBS:+-j$JOBS} install
 
 # Make backward compatible in case a depending (older) package still needs libVMC.so
 cd $INSTALLROOT/lib
-case $ARCHITECTURE in
-  osx*)
-      ln -s libVMCLibrary.dylib libVMC.dylib
-  ;;
-  *)
-      ln -s libVMCLibrary.so libVMC.so
-  ;;
-esac
+ln -s libVMCLibrary.so libVMC.so
 # update modulefile
 cat >> "$MODULEFILE" <<EoF
 # Our environment

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -3,6 +3,7 @@ version: v3.3.0
 source: https://github.com/apache/xerces-c
 build_requires:
   - GCC-Toolchain:(?!osx)
+  - alibuild-recipe-tools
 env:
   XERCESC_INST_DIR: "$XERCESC_ROOT"
   XERCESCINST: "$XERCESC_ROOT"
@@ -26,25 +27,10 @@ make ${JOBS+-j $JOBS}
 make install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0
-# Our environment
-setenv XERCESC_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-setenv XERCESCROOT \$::env(XERCESC_ROOT)
-setenv XERCESC_INST_DIR \$::env(XERCESC_ROOT)
-setenv XERCESCINST \$::env(XERCESC_ROOT)
-prepend-path PATH \$::env(XERCESC_ROOT)/bin
-prepend-path LD_LIBRARY_PATH \$::env(XERCESC_ROOT)/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(XERCESC_ROOT)/lib")
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
+setenv XERCESCROOT \$PKG_ROOT
+setenv XERCESC_INST_DIR \$PKG_ROOT
+setenv XERCESCINST \$PKG_ROOT
 EoF

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -2,7 +2,7 @@ package: XercesC
 version: v3.3.0
 source: https://github.com/apache/xerces-c
 build_requires:
-  - GCC-Toolchain:(?!osx)
+  - GCC-Toolchain
   - alibuild-recipe-tools
 env:
   XERCESC_INST_DIR: "$XERCESC_ROOT"

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -3,14 +3,13 @@ version: "%(tag_basename)s"
 tag: "v5.8.4"
 source: https://github.com/xrootd/xrootd
 requires:
-  - "OpenSSL:(?!osx)"
+  - OpenSSL
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
   - libxml2
 build_requires:
   - CMake
-  - "osx-system-openssl:(osx.*)"
-  - "GCC-Toolchain:(?!osx)"
+  - GCC-Toolchain
   - UUID
   - alibuild-recipe-tools
 prepend_path:
@@ -36,35 +35,6 @@ COMPILER_CXX=c++
 COMPILER_LD=c++
 SONAME=so
 
-case $ARCHITECTURE in
-  osx_x86-64)
-    export ARCHFLAGS="-arch x86_64"
-    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl@3)
-
-    # NOTE: Python from Homebrew will have a hardcoded sysroot pointing to Xcode.app directory wchich might not exist.
-    # This seems to be a robust way to discover a working SDK path and present it to Python setuptools.
-    # This fix is needed only on MacOS when building XRootD Python bindings.
-    export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
-    COMPILER_CC=clang
-    COMPILER_CXX=clang++
-    COMPILER_LD=clang
-    SONAME=dylib
-  ;;
-  osx_arm64)
-    [[ $OPENSSL_ROOT ]] || OPENSSL_ROOT=$(brew --prefix openssl@3)
-    CMAKE_FRAMEWORK_PATH=$(brew --prefix)/Frameworks
-
-    # NOTE: Python from Homebrew will have a hardcoded sysroot pointing to Xcode.app directory wchich might not exist.
-    # This seems to be a robust way to discover a working SDK path and present it to Python setuptools.
-    # This fix is needed only on MacOS when building XRootD Python bindings.
-    export CFLAGS="${CFLAGS} -isysroot $(xcrun --show-sdk-path)"
-    COMPILER_CC=clang
-    COMPILER_CXX=clang++
-    COMPILER_LD=clang
-    SONAME=dylib
-  ;;
-esac
-
 rsync -a --delete ${SOURCEDIR}/ ${BUILDDIR}
 
 mkdir build
@@ -75,7 +45,6 @@ cmake "${BUILDDIR}"                                                   \
       -DCMAKE_C_COMPILER=$COMPILER_CC                                 \
       -DCMAKE_LINKER=$COMPILER_LD                                     \
       -DCMAKE_INSTALL_PREFIX=${INSTALLROOT}                           \
-      ${CMAKE_FRAMEWORK_PATH+-DCMAKE_FRAMEWORK_PATH=$CMAKE_FRAMEWORK_PATH} \
       -DCMAKE_INSTALL_LIBDIR=lib                                      \
       -DXRDCL_ONLY=ON                                                 \
       ${UUID_ROOT:+-DUUID_LIBRARIES=$UUID_ROOT/lib/libuuid.so}        \
@@ -121,13 +90,6 @@ if [[ x"$XROOTD_PYTHON" == x"True" ]]; then
     popd  # get back from lib
 
     popd  # get back from INSTALLROOT
-
-  case $ARCHITECTURE in
-      osx*)
-        find $INSTALLROOT/lib/python/ -name "*.so" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
-        find $INSTALLROOT/lib/ -name "*.dylib" -exec install_name_tool -add_rpath ${INSTALLROOT}/lib {} \;
-      ;;
-  esac
 
     # Print found XRootD python bindings
     # just run the the command as this is under "bash -e"

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -6,6 +6,7 @@ requires:
   - boost
 build_requires:
   - CMake
+  - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
   pkg-config --atleast-version=0.6.2 yaml-cpp && printf "#include \"yaml-cpp/yaml.h\"\n" | c++ -std=c++17 -I`brew --prefix yaml-cpp`/include -I`brew --prefix boost`/include -xc++ - -c -o /dev/null
@@ -30,20 +31,5 @@ cmake $SOURCEDIR                                         \
 make ${JOBS+-j $JOBS} install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${BOOST_REVISION:+boost/$BOOST_VERSION-$BOOST_REVISION}
-# Our environment
-set YAMLCPP \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path LD_LIBRARY_PATH \$YAMLCPP/lib
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -9,14 +9,9 @@ build_requires:
   - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
-  pkg-config --atleast-version=0.6.2 yaml-cpp && printf "#include \"yaml-cpp/yaml.h\"\n" | c++ -std=c++17 -I`brew --prefix yaml-cpp`/include -I`brew --prefix boost`/include -xc++ - -c -o /dev/null
+  pkg-config --atleast-version=0.6.2 yaml-cpp && printf "#include \"yaml-cpp/yaml.h\"\n" | c++ -std=c++17 -I$BOOST_ROOT/include -xc++ - -c -o /dev/null
 ---
 #!/bin/sh
-case $ARCHITECTURE in
-  osx*) [[ $BOOST_ROOT ]] || BOOST_ROOT=`brew --prefix boost` ;;
-  *) ;;
-esac
-
 cmake $SOURCEDIR                                         \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"             \
   -DBUILD_SHARED_LIBS=YES                                \

--- a/zlib.sh
+++ b/zlib.sh
@@ -4,6 +4,7 @@ source: https://github.com/star-externals/zlib
 tag: v1.2.8
 build_requires:
  - "GCC-Toolchain:(?!osx)"
+ - alibuild-recipe-tools
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <zlib.h>\n" | gcc -xc++ - -c -M 2>&1
@@ -30,20 +31,5 @@ make ${JOBS+-j $JOBS}
 make install
 
 # Modulefile
-MODULEDIR="$INSTALLROOT/etc/modulefiles"
-MODULEFILE="$MODULEDIR/$PKGNAME"
-mkdir -p "$MODULEDIR"
-cat > "$MODULEFILE" <<EoF
-#%Module1.0
-proc ModulesHelp { } {
-  global version
-  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-}
-set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
-module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
-# Dependencies
-module load BASE/1.0 ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
-# Our environment
-prepend-path LD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib
-$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(BASEDIR)/$PKGNAME/\$version/lib")
-EoF
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/zlib.sh
+++ b/zlib.sh
@@ -3,8 +3,8 @@ version: "%(tag_basename)s"
 source: https://github.com/star-externals/zlib
 tag: v1.2.8
 build_requires:
- - "GCC-Toolchain:(?!osx)"
- - alibuild-recipe-tools
+  - GCC-Toolchain
+  - alibuild-recipe-tools
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   printf "#include <zlib.h>\n" | gcc -xc++ - -c -M 2>&1


### PR DESCRIPTION
## Summary
- Remove macOS conditionals from YAML headers and build scripts
- Convert modulefiles to use alibuild-generate-module
- Update incremental recipes to use alibuild-generate-module
- Remove stale APFEL .la workaround from GENIE

## Test plan
- [x] Full FairShip build on SLC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced standardized modulefile generation across all packages for consistent environment module handling.

* **Refactor**
  * Unified build requirements by removing platform-specific conditional constraints, simplifying dependency resolution.
  * Removed architecture-specific build logic and macOS-exclusive conditionals for cleaner, more maintainable recipes.
  * Simplified environment variable configuration by removing conditional dynamic library path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->