### PR TITLE
fix(acts): use relative symlink for lib -> lib64

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -41,7 +41,7 @@ cmake "$SOURCEDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
 
 cmake --build . -- ${JOBS:+-j$JOBS} install
 
-[[ -d "$INSTALLROOT/lib64" ]] && [[ ! -d "$INSTALLROOT/lib" ]] && ln -sf "${INSTALLROOT}/lib64" "$INSTALLROOT/lib"
+[[ -d "$INSTALLROOT/lib64" ]] && [[ ! -d "$INSTALLROOT/lib" ]] && ln -sf lib64 "$INSTALLROOT/lib"
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
## Summary
- The absolute symlink `lib -> /opt/ship/.../lib64` causes `Too many levels of symbolic links` during the `relocate-me.sh` step when unpacking from the S3 remote store
- Use a relative symlink (`lib -> lib64`) instead, which works after relocation

## Test plan
- [x] Rebuild ACTS tarball and verify it unpacks without error
- [x] Verify the `lib/pkgconfig/nlohmann_json.pc` symlink resolves correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed symlink creation during installation on systems using lib64 directory layouts, ensuring proper relative path handling for library directories. This improves compatibility with systems where lib64 exists but lib does not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->