### PR TITLE
fix(rootegpythia6): patch absolute paths in dict autoload annotations

### DIFF
--- a/rootegpythia6.sh
+++ b/rootegpythia6.sh
@@ -21,6 +21,15 @@ prefer_system_check: |
 ---
 #!/bin/bash -e
 
+# Patch CMakeLists.txt to pass bare header names to ROOT_GENERATE_DICTIONARY
+# instead of absolute paths. Absolute paths get embedded in the dictionary's
+# $clingAutoload$ annotations, causing errors at runtime when the source
+# directory no longer exists (e.g. on CVMFS).
+sed -i \
+  -e 's|${CMAKE_CURRENT_LIST_DIR}/inc/\(.*\.h\)|\1|g' \
+  -e '/^ROOT_GENERATE_DICTIONARY/i include_directories(${CMAKE_CURRENT_LIST_DIR}/inc)' \
+  "$SOURCEDIR/CMakeLists.txt"
+
 cmake "$SOURCEDIR" \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \


### PR DESCRIPTION
Absolute source paths passed to ROOT_GENERATE_DICTIONARY get embedded in the shared library's $clingAutoload$ annotations. At runtime, cling tries to resolve these paths, but the source directory no longer exists on CVMFS, producing errors like:

  Error in cling::AutoLoadingVisitor::InsertIntoAutoLoadingState:
    Missing FileEntry for .../SOURCES/ROOTEGPythia6/.../inc/TMCParticle.h

Patch the CMakeLists.txt at build time to pass bare header names instead and add an include_directories() call so rootcling can still find them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration scripts to optimize header file inclusion paths and references.

---

**Note:** This release contains internal build system improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->