### PR TITLE
Drop incremental_recipe from root and fairlogger

### DIFF
--- a/fairlogger.sh
+++ b/fairlogger.sh
@@ -8,13 +8,6 @@ build_requires:
  - CMake
  - GCC-Toolchain
  - alibuild-recipe-tools
-incremental_recipe: |
-  cmake --build . --target install ${JOBS:+-- -j$JOBS}
-  mkdir -p "$INSTALLROOT/etc/modulefiles"
-  alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
-  cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<\EoF
-  prepend-path ROOT_INCLUDE_PATH $PKG_ROOT/include
-  EoF
 prepend_path:
   ROOT_INCLUDE_PATH: "$FAIRLOGGER_ROOT/include"
 prefer_system_check: |

--- a/root.sh
+++ b/root.sh
@@ -50,13 +50,6 @@ prefer_system_check: |
   for FEATURE in $FEATURES; do
       root-config --has-$FEATURE | grep -q yes || { echo "$FEATURE missing"; exit 1; }
   done
-incremental_recipe: |
-  #!/bin/bash -e
-  make ${JOBS:+-j$JOBS} install
-  mkdir -p $INSTALLROOT/etc/modulefiles
-  rsync -a --delete etc/modulefiles/ $INSTALLROOT/etc/modulefiles
-  cd $INSTALLROOT/test
-  env PATH=$INSTALLROOT/bin:$PATH LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH make ${JOBS+-j$JOBS}
 ---
 #!/bin/bash -e
 unset ROOTSYS


### PR DESCRIPTION
## Summary
- Remove `incremental_recipe` from `root.sh` and `fairlogger.sh`
- These add maintenance burden with little benefit
- Keep only the FairShip incremental recipe