### PR TITLE
Adding pytest build instruction

### DIFF
--- a/fairship.sh
+++ b/fairship.sh
@@ -20,6 +20,7 @@ requires:
   - python-matplotlib
   - python-pandas
   - python-pyyaml
+  - python-pytest-xdist
   - python-scipy
   - python-tabulate
   - python-uproot

--- a/python-execnet.sh
+++ b/python-execnet.sh
@@ -1,26 +1,24 @@
-package: python-pytest-xdist
-version: "3.8.0"
+package: python-execnet
+version: "2.1.1"
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
-  - python-execnet
-  - python-pytest
 build_requires:
   - uv
   - alibuild-recipe-tools
 prefer_system_check: |
-  python3 -c 'import xdist; print(xdist.__version__)' || exit 1
-  SYSTEM_VERSION=$(python3 -c 'import xdist; print(xdist.__version__)')
+  python3 -c 'import execnet; print(execnet.__version__)' || exit 1
+  SYSTEM_VERSION=$(python3 -c 'import execnet; print(execnet.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYTEST_XDIST_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_EXECNET_ROOT/lib/python/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
 TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
 mkdir -p "$TARGET"
 
-uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest-xdist==$PKGVERSION"
+uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "execnet==$PKGVERSION"
 
 ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 

--- a/python-iniconfig.sh
+++ b/python-iniconfig.sh
@@ -1,26 +1,24 @@
-package: python-pytest-xdist
-version: "3.8.0"
+package: python-iniconfig
+version: "2.1.0"
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
-  - python-execnet
-  - python-pytest
 build_requires:
   - uv
   - alibuild-recipe-tools
 prefer_system_check: |
-  python3 -c 'import xdist; print(xdist.__version__)' || exit 1
-  SYSTEM_VERSION=$(python3 -c 'import xdist; print(xdist.__version__)')
+  python3 -c 'import iniconfig; print(iniconfig.__version__)' || exit 1
+  SYSTEM_VERSION=$(python3 -c 'import iniconfig; print(iniconfig.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYTEST_XDIST_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_INICONFIG_ROOT/lib/python/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
 TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
 mkdir -p "$TARGET"
 
-uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest-xdist==$PKGVERSION"
+uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "iniconfig==$PKGVERSION"
 
 ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 

--- a/python-pluggy.sh
+++ b/python-pluggy.sh
@@ -1,26 +1,24 @@
-package: python-pytest-xdist
-version: "3.8.0"
+package: python-pluggy
+version: "1.6.0"
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
-  - python-execnet
-  - python-pytest
 build_requires:
   - uv
   - alibuild-recipe-tools
 prefer_system_check: |
-  python3 -c 'import xdist; print(xdist.__version__)' || exit 1
-  SYSTEM_VERSION=$(python3 -c 'import xdist; print(xdist.__version__)')
+  python3 -c 'import pluggy; print(pluggy.__version__)' || exit 1
+  SYSTEM_VERSION=$(python3 -c 'import pluggy; print(pluggy.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYTEST_XDIST_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PLUGGY_ROOT/lib/python/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
 TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
 mkdir -p "$TARGET"
 
-uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest-xdist==$PKGVERSION"
+uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pluggy==$PKGVERSION"
 
 ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 

--- a/python-pygments.sh
+++ b/python-pygments.sh
@@ -1,26 +1,24 @@
-package: python-pytest-xdist
-version: "3.8.0"
+package: python-pygments
+version: "2.19.2"
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
-  - python-execnet
-  - python-pytest
 build_requires:
   - uv
   - alibuild-recipe-tools
 prefer_system_check: |
-  python3 -c 'import xdist; print(xdist.__version__)' || exit 1
-  SYSTEM_VERSION=$(python3 -c 'import xdist; print(xdist.__version__)')
+  python3 -c 'import pygments; print(pygments.__version__)' || exit 1
+  SYSTEM_VERSION=$(python3 -c 'import pygments; print(pygments.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYTEST_XDIST_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PYGMENTS_ROOT/lib/python/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
 TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
 mkdir -p "$TARGET"
 
-uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest-xdist==$PKGVERSION"
+uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pygments==$PKGVERSION"
 
 ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 

--- a/python-pytest-xdist.sh
+++ b/python-pytest-xdist.sh
@@ -1,0 +1,31 @@
+package: python-pytest-xdist
+version: "3.8.0"
+requires:
+  - "Python:(slc|ubuntu)"
+  - "Python-system:(?!slc.*|ubuntu)"
+  - python-pytest
+build_requires:
+  - uv
+  - alibuild-recipe-tools
+prefer_system_check: |
+  python3 -c 'import xdist; print(xdist.__version__)' || exit 1
+  SYSTEM_VERSION=$(python3 -c 'import xdist; print(xdist.__version__)')
+  printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
+prepend_path:
+  PYTHONPATH: "$PYTHON_PYTEST_XDIST_ROOT/lib/python/site-packages"
+---
+#!/bin/bash -e
+pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
+TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
+mkdir -p "$TARGET"
+
+uv pip install --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest-xdist==$PKGVERSION"
+
+ln -snf "python$pyver" "$INSTALLROOT/lib/python"
+
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
+set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+EOF

--- a/python-pytest.sh
+++ b/python-pytest.sh
@@ -22,12 +22,14 @@ mkdir -p "$TARGET"
 uv pip install --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest==$PKGVERSION"
 ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 
-# Move entrypoints such as pytest/py.test into the package bin directory.
-if [ -d "$TARGET/../../../bin" ]; then
-  mkdir -p "$INSTALLROOT/bin"
-  mv "$TARGET/../../../bin"/* "$INSTALLROOT/bin/"
-  rmdir "$TARGET/../../../bin" 2>/dev/null || true
-fi
+# Install stable entrypoint wrappers that always use the loaded aliBuild Python.
+mkdir -p "$INSTALLROOT/bin"
+cat > "$INSTALLROOT/bin/pytest" <<'EOF'
+#!/bin/sh
+exec python3 -m pytest "$@"
+EOF
+chmod +x "$INSTALLROOT/bin/pytest"
+ln -snf pytest "$INSTALLROOT/bin/py.test"
 
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/python-pytest.sh
+++ b/python-pytest.sh
@@ -22,15 +22,6 @@ mkdir -p "$TARGET"
 uv pip install --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest==$PKGVERSION"
 ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 
-# Install stable entrypoint wrappers that always use the loaded aliBuild Python.
-mkdir -p "$INSTALLROOT/bin"
-cat > "$INSTALLROOT/bin/pytest" <<'EOF'
-#!/bin/sh
-exec python3 -m pytest "$@"
-EOF
-chmod +x "$INSTALLROOT/bin/pytest"
-ln -snf pytest "$INSTALLROOT/bin/py.test"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF

--- a/python-pytest.sh
+++ b/python-pytest.sh
@@ -1,0 +1,38 @@
+package: python-pytest
+version: "8.4.2"
+requires:
+  - "Python:(slc|ubuntu)"
+  - "Python-system:(?!slc.*|ubuntu)"
+build_requires:
+  - uv
+  - alibuild-recipe-tools
+prefer_system_check: |
+  python3 -c 'import pytest; print(pytest.__version__)' || exit 1
+  SYSTEM_VERSION=$(python3 -c 'import pytest; print(pytest.__version__)')
+  printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
+prepend_path:
+  PYTHONPATH: "$PYTHON_PYTEST_ROOT/lib/python/site-packages"
+  PATH: "$PYTHON_PYTEST_ROOT/bin"
+---
+#!/bin/bash -e
+pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
+TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
+mkdir -p "$TARGET"
+
+uv pip install --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest==$PKGVERSION"
+ln -snf "python$pyver" "$INSTALLROOT/lib/python"
+
+# Move entrypoints such as pytest/py.test into the package bin directory.
+if [ -d "$TARGET/../../../bin" ]; then
+  mkdir -p "$INSTALLROOT/bin"
+  mv "$TARGET/../../../bin"/* "$INSTALLROOT/bin/"
+  rmdir "$TARGET/../../../bin" 2>/dev/null || true
+fi
+
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
+set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PATH \$PKG_ROOT/bin
+EOF

--- a/python-pytest.sh
+++ b/python-pytest.sh
@@ -3,6 +3,10 @@ version: "8.4.2"
 requires:
   - "Python:(slc|ubuntu)"
   - "Python-system:(?!slc.*|ubuntu)"
+  - python-iniconfig
+  - python-packaging
+  - python-pluggy
+  - python-pygments
 build_requires:
   - uv
   - alibuild-recipe-tools
@@ -19,8 +23,17 @@ pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
 TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
 mkdir -p "$TARGET"
 
-uv pip install --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest==$PKGVERSION"
+uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest==$PKGVERSION"
 ln -snf "python$pyver" "$INSTALLROOT/lib/python"
+
+# Install stable entrypoint wrappers that always use the loaded aliBuild Python.
+mkdir -p "$INSTALLROOT/bin"
+cat > "$INSTALLROOT/bin/pytest" <<'EOF'
+#!/bin/sh
+exec python3 -m pytest "$@"
+EOF
+chmod +x "$INSTALLROOT/bin/pytest"
+ln -snf pytest "$INSTALLROOT/bin/py.test"
 
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pytest (v8.4.2) and pytest-xdist (v3.8.0) for running tests, including parallel test distribution.
  * Added several Python helper packages (execnet, iniconfig, pluggy, pygments) to the environment.

* **Chores**
  * Updated environment/module setup so installed packages and test executables are available via PYTHONPATH and PATH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->