### PR TITLE
fix(evtgen): make exported CMake targets relocatable

### DIFF
--- a/evtgen.sh
+++ b/evtgen.sh
@@ -36,6 +36,19 @@ cmake $SOURCEDIR -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
       ${TAUOLAPP_ROOT:+-DTAUOLAPP_ROOT_DIR=$TAUOLAPP_ROOT}
 make ${JOBS:+-j$JOBS} install
 
+# Make the exported CMake targets relocatable across CVMFS prefixes.
+# Upstream EvtGen bakes absolute build-time paths to HepMC3/pythia/PHOTOSPP/
+# Tauolapp into share/EvtGen/cmake/EvtGenTargets.cmake; replace each
+# dependency's install prefix with a $ENV{...}_ROOT reference so the tarball
+# can be consumed under any CVMFS prefix where alibuild's runtime env is set.
+TARGETS_CMAKE="$INSTALLROOT/share/EvtGen/cmake/EvtGenTargets.cmake"
+if [ -f "$TARGETS_CMAKE" ]; then
+    [ -n "$HEPMC3_ROOT" ]   && sed -i "s|${HEPMC3_ROOT}|\$ENV{HEPMC3_ROOT}|g"     "$TARGETS_CMAKE"
+    [ -n "$PYTHIA_ROOT" ]   && sed -i "s|${PYTHIA_ROOT}|\$ENV{PYTHIA_ROOT}|g"     "$TARGETS_CMAKE"
+    [ -n "$PHOTOSPP_ROOT" ] && sed -i "s|${PHOTOSPP_ROOT}|\$ENV{PHOTOSPP_ROOT}|g" "$TARGETS_CMAKE"
+    [ -n "$TAUOLAPP_ROOT" ] && sed -i "s|${TAUOLAPP_ROOT}|\$ENV{TAUOLA_ROOT}|g" "$TARGETS_CMAKE"
+fi
+
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"


### PR DESCRIPTION
Upstream EvtGen bakes absolute build-time paths to HepMC3, pythia, PHOTOSPP and Tauolapp into share/EvtGen/cmake/EvtGenTargets.cmake. A tarball produced on one CVMFS cluster (e.g. ship-nightlies) therefore fails to configure on a different cluster (e.g. ship.cern.ch/26.04) because the absolute paths to the dependencies' install prefixes do not exist there, and downstream consumers like FairShip abort at the CMake generate step with:

    Imported target "EvtGen::EvtGen" includes non-existent path
    "/cvmfs/ship-nightlies.cern.ch/next/sw/.../HepMC3/.../include"

Patch the generated EvtGenTargets.cmake post-install so each dependency's install prefix is replaced with a $ENV{<DEP>_ROOT} reference. CMake expands $ENV{} when the consumer include()s the targets file, and alibuild always sets these vars in the consumer's build environment, so the tarball becomes portable across CVMFS prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced installation portability by making the build system dynamically adjust dependency paths based on environment variables, allowing installations to work across different CVMFS locations when runtime environment variables are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->