### PR TITLE
fix(alibuild): correct script path for uv pip install --target

### DIFF
--- a/alibuild.sh
+++ b/alibuild.sh
@@ -32,7 +32,7 @@ ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 
 # Move scripts installed into the target to the bin directory
 mkdir -p "$INSTALLROOT/bin"
-mv "$TARGET/../../../bin"/* "$INSTALLROOT/bin/"
+mv "$TARGET/bin"/* "$INSTALLROOT/bin/"
 
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"


### PR DESCRIPTION
uv places console scripts under <target>/bin/, not <target>/../../../bin/ as pip does. The build was failing on the mv step because the source directory did not exist.