### PR TITLE
fix(fairship): skip empty-version dep loads in modulefile

### DIFF
--- a/fairship.sh
+++ b/fairship.sh
@@ -59,7 +59,18 @@ incremental_recipe: |
   cd "$BUILDDIR" || exit
   # Modulefile
   mkdir -p "$INSTALLROOT/etc/modulefiles"
-  alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+  # Drop deps with empty *_VERSION (happens for some deps when building
+  # locally on top of CVMFS) so we don't emit broken `module load pkg/-N`
+  # lines. Pre-filter unsets *_REVISION so alibuild-generate-module skips
+  # them; sed is a defense-in-depth post-filter.
+  ( for __v in $(compgen -A variable | grep '_REVISION$'); do
+      __p=${__v%_REVISION}
+      eval "__ver=\${${__p}_VERSION-}"
+      [ -z "$__ver" ] && unset "$__v"
+    done
+    alibuild-generate-module --bin --lib
+  ) | sed -E '/is-loaded "[^"\/]+\/-[0-9]+"/d' \
+      > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
   cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
   setenv FAIRSHIP_HASH $FAIRSHIP_HASH
   setenv FAIRSHIP \$PKG_ROOT
@@ -119,7 +130,18 @@ cd "$BUILDDIR" || exit
 
 # Modulefile
 mkdir -p "$INSTALLROOT/etc/modulefiles"
-alibuild-generate-module --bin --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
+# Drop deps with empty *_VERSION (happens for some deps when building
+# locally on top of CVMFS) so we don't emit broken `module load pkg/-N`
+# lines. Pre-filter unsets *_REVISION so alibuild-generate-module skips
+# them; sed is a defense-in-depth post-filter.
+( for __v in $(compgen -A variable | grep '_REVISION$'); do
+    __p=${__v%_REVISION}
+    eval "__ver=\${${__p}_VERSION-}"
+    [ -z "$__ver" ] && unset "$__v"
+  done
+  alibuild-generate-module --bin --lib
+) | sed -E '/is-loaded "[^"\/]+\/-[0-9]+"/d' \
+    > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EoF
 setenv FAIRSHIP_HASH $FAIRSHIP_HASH
 setenv FAIRSHIP \$PKG_ROOT


### PR DESCRIPTION
When building FairShip locally on top of the CVMFS environment, some deps end up with `*_REVISION` set but `*_VERSION` empty in the build env, which made `alibuild-generate-module` emit broken `module load pkg/-N` lines that no module loader can resolve.

Pre-filter unsets `*_REVISION` whenever `*_VERSION` is empty so alibuild-generate-module skips the dep at the source; sed serves as a defense-in-depth post-filter. Restores the skip-if-VERSION-empty behaviour the hand-written modulefile had via `${VAR:+...}` before db13d4de, while keeping the auto-generated full dep list (which catches the Python packages the hand-written list missed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module file generation to prevent broken module load entries by filtering out incomplete dependencies from build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->