### PR TITLE
Upgrade recipes for ubuntu26 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ## Unreleased
 
+### Changed
+
+* yaml-cpp: Upgrade to 0.9.0 to fix issue with modern gcc https://github.com/jbeder/yaml-cpp/issues/1307
+* xrootd: Add dist-packages as a possible location for python bindings
+
 ## [26.04](https://github.com/ShipSoft/shipdist/tree/26.04)
 
 ### Added

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -93,9 +93,15 @@ if [[ "$XROOTD_PYTHON" == "True" ]]; then
 
     # Print found XRootD python bindings
     # just run the the command as this is under "bash -e"
-    echo -ne ">>>>>>   Found XRootD python bindings: "
-    LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
-    echo
+    if [ -d "$INSTALLROOT/lib/python/dist-packages" ]; then
+     echo -ne ">>>>>>   Found XRootD python bindings: "
+     LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/dist-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
+     echo
+    else
+     echo -ne ">>>>>>   Found XRootD python bindings: "
+     LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
+     echo
+    fi
 
 fi  # end of PYTHON part
 

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -94,14 +94,13 @@ if [[ "$XROOTD_PYTHON" == "True" ]]; then
     # Print found XRootD python bindings
     # just run the the command as this is under "bash -e"
     if [ -d "$INSTALLROOT/lib/python/dist-packages" ]; then
-     echo -ne ">>>>>>   Found XRootD python bindings: "
-     LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/dist-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
-     echo
+     XROOTD_PYTHON_PKG_DIR="dist-packages"
     else
-     echo -ne ">>>>>>   Found XRootD python bindings: "
-     LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
-     echo
+     XROOTD_PYTHON_PKG_DIR="site-packages"
     fi
+     echo -ne ">>>>>>   Found XRootD python bindings: "
+     LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/${XROOTD_PYTHON_PKG_DIR}${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
+     echo
 
 fi  # end of PYTHON part
 
@@ -114,7 +113,7 @@ alibuild-generate-module --bin --lib > "$MODULEFILE"
 
 cat >> "$MODULEFILE" <<EoF
 if { $XROOTD_PYTHON } {
-  prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+  prepend-path PYTHONPATH \$PKG_ROOT/lib/python/${XROOTD_PYTHON_PKG_DIR}
   module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}
 }
 EoF

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -1,6 +1,6 @@
 package: yaml-cpp
 version: "%(tag_basename)s"
-tag: 0.8.0
+tag: yaml-cpp-0.9.0
 source: https://github.com/jbeder/yaml-cpp
 build_requires:
   - CMake


### PR DESCRIPTION
First shipdist build with Ubuntu 26.04 LTS.

Some minor changes required at the following recipes:

- yaml-cpp version 0.8.0 fails to build with modern gcc, >15.0. This is a known issue, https://github.com/jbeder/yaml-cpp/issues/1307, just upgrade to 0.9.0 fixes it automatically;
- xrootd fails to find python bindings in python/site-packages folder. Looking at the folder manually, I have found that in Ubuntu26.04 it is named python/dist-packages. Fixed with an if-else condition.

Tested with shipdist release 26.04.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated yaml-cpp to version 0.9.0
  * Enhanced XRootD Python bindings detection to check for additional library installation paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->