### PR TITLE
Add Renovate Bot config for automatic dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     {
       "customType": "regex",
       "description": "Update tags in alibuild recipes (GitHub sources)",
-      "fileMatch": ["\\.sh$"],
+      "managerFilePatterns": ["/\\.sh$/"],
       "matchStringsStrategy": "combination",
       "matchStrings": [
         "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
@@ -16,7 +16,7 @@
     {
       "customType": "regex",
       "description": "Update tags in alibuild recipes (GitLab CERN sources)",
-      "fileMatch": ["\\.sh$"],
+      "managerFilePatterns": ["/\\.sh$/"],
       "matchStringsStrategy": "combination",
       "matchStrings": [
         "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
@@ -28,7 +28,7 @@
     {
       "customType": "regex",
       "description": "Update tags in alibuild recipes (GitLab.com sources)",
-      "fileMatch": ["\\.sh$"],
+      "managerFilePatterns": ["/\\.sh$/"],
       "matchStringsStrategy": "combination",
       "matchStrings": [
         "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update tags in alibuild recipes (GitHub sources)",
+      "fileMatch": ["\\.sh$"],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
+        "source:\\s*https://github\\.com/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*$"
+      ],
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "description": "Update tags in alibuild recipes (GitLab CERN sources)",
+      "fileMatch": ["\\.sh$"],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
+        "source:\\s*https://gitlab\\.cern\\.ch/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*$"
+      ],
+      "datasourceTemplate": "gitlab-tags",
+      "registryUrlTemplate": "https://gitlab.cern.ch"
+    },
+    {
+      "customType": "regex",
+      "description": "Update tags in alibuild recipes (GitLab.com sources)",
+      "fileMatch": ["\\.sh$"],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
+        "source:\\s*https://gitlab\\.com/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*$"
+      ],
+      "datasourceTemplate": "gitlab-tags",
+      "registryUrlTemplate": "https://gitlab.com"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Use loose versioning for alibuild recipes",
+      "matchManagers": ["custom.regex"],
+      "versioning": "loose"
+    },
+    {
+      "description": "Packages tracking branches, not release tags",
+      "matchPackageNames": [
+        "ShipSoft/FairShip",
+        "luketpickering/ROOTEGPythia6",
+        "ktf/pcre",
+        "hepmc/HepMC3"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Forks with custom tag schemes that don't match upstream",
+      "matchPackageNames": [
+        "alisw/boost",
+        "alisw/hepmc",
+        "alisw/gsl",
+        "alisw/libxml2",
+        "alisw/uuid",
+        "alisw/sqlite",
+        "alisw/liblzma",
+        "alisw/autotools",
+        "alisw/gcc-toolchain",
+        "star-externals/zlib",
+        "SND-LHC/pythia6",
+        "webbjm/acts",
+        "Kitware/ninja"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group all Python package updates together",
+      "matchFileNames": ["python-*.sh"],
+      "groupName": "python packages"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "schedule": ["every weekend"],
+  "prConcurrentLimit": 5,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Custom regex managers detect tag/source pairs in alibuild recipe files and check for new upstream releases on GitHub and GitLab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency-update configuration that scans shell scripts and groups Python-related updates.
  * Enabled pattern-based lookups for GitHub and GitLab tags to discover script-referenced package versions.
  * Applied selective update policies: relaxed versioning for pattern-managed updates and disabled updates for branch-tracking or incompatible forked packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->