### PR TITLE
Autotools: switch from ALICE fork to upstream GNU repos

### DIFF
--- a/autoconf.sh
+++ b/autoconf.sh
@@ -1,0 +1,29 @@
+package: autoconf
+version: "%(tag_basename)s"
+tag: v2.72
+source: https://git.savannah.gnu.org/git/autoconf.git
+requires:
+  - m4
+build_requires:
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: .*
+prefer_system_check: |
+  autoconf --version
+---
+#!/bin/bash -e
+rsync -a --delete --exclude '**/.git' --delete-excluded "$SOURCEDIR/" ./
+
+if [[ -x ./bootstrap ]]; then
+  ./bootstrap
+elif [[ -f configure.ac ]]; then
+  autoreconf -ivf
+fi
+
+./configure --prefix="$INSTALLROOT"
+make MAKEINFO=true ${JOBS+-j $JOBS}
+make MAKEINFO=true install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/automake.sh
+++ b/automake.sh
@@ -1,0 +1,30 @@
+package: automake
+version: "%(tag_basename)s"
+tag: v1.17
+source: https://git.savannah.gnu.org/git/automake.git
+requires:
+  - m4
+  - autoconf
+build_requires:
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: .*
+prefer_system_check: |
+  automake --version
+---
+#!/bin/bash -e
+rsync -a --delete --exclude '**/.git' --delete-excluded "$SOURCEDIR/" ./
+
+if [[ -x ./bootstrap ]]; then
+  ./bootstrap
+elif [[ -f configure.ac ]]; then
+  autoreconf -ivf
+fi
+
+./configure --prefix="$INSTALLROOT"
+make MAKEINFO=true ${JOBS+-j $JOBS}
+make MAKEINFO=true install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/autotools.sh
+++ b/autotools.sh
@@ -1,8 +1,14 @@
 package: autotools
-version: "%(tag_basename)s"
-tag: v1.6.4
-source: https://github.com/alisw/autotools
-prefer_system: "(?!slc5|slc6)"
+version: "2.0"
+requires:
+  - m4
+  - autoconf
+  - automake
+  - libtool
+  - gettext
+  - help2man
+  - pkg-config
+prefer_system: .*
 prefer_system_check: |
   for bin in autoconf m4 automake makeinfo aclocal pkg-config autopoint libtool; do
     if ! command -v "$bin" >/dev/null 2>&1; then
@@ -16,152 +22,8 @@ prefer_system_check: |
       exit 1
     fi
   done
-prepend_path:
-  PKG_CONFIG_PATH: >-
-    $(pkg-config --debug 2>&1 |
-    grep 'Scanning directory' |
-    sed -e "s/.*'\(.*\)'/\1/" |
-    xargs echo | sed -e 's/ /:/g')
-build_requires:
-  - termcap
-  - make
 ---
-#!/bin/bash -e
-
-unset CXXFLAGS
-unset CFLAGS
-export EMACS=no
-
-case $ARCHITECTURE in
-  slc6*) USE_AUTORECONF=${USE_AUTORECONF:="false"} ;;
-  *) USE_AUTORECONF=${USE_AUTORECONF:="true"} ;;
-esac
-
-echo "Building ALICE autotools. To avoid this install autoconf, automake, autopoint, texinfo, pkg-config."
-
-# Restore original timestamps to avoid reconf (Git does not preserve them)
-pushd $SOURCEDIR
-  ./missing-timestamps.sh --apply
-popd
-
-rsync -a --delete --exclude '**/.git' $SOURCEDIR/ .
-
-# Use our auto* tools as we build them
-export PATH=$INSTALLROOT/bin:$PATH
-export LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH
-
-# help2man
-if pushd help2man*; then
-  ./configure --disable-dependency-tracking --prefix "$INSTALLROOT"
-  make ${JOBS+-j $JOBS}
-  make install
-  hash -r
-  popd
-fi
-
-# m4 -- requires: nothing special
-pushd m4*
-  sed -i '1 i @documentencoding ISO-8859-1' doc/m4.texi
-  $USE_AUTORECONF && autoreconf -ivf
-  ./configure --disable-dependency-tracking --prefix $INSTALLROOT
-  make ${JOBS+-j $JOBS}
-  make install
-  hash -r
-popd
-
-# autoconf -- requires: m4
-# FIXME: is that really true? on slc7 it fails if I do it the other way around
-# with the latest version of autoconf / m4
-pushd autoconf*
-  $USE_AUTORECONF && autoreconf -ivf
-  ./configure --prefix $INSTALLROOT
-  make MAKEINFO=true ${JOBS+-j $JOBS}
-  make MAKEINFO=true install
-  hash -r
-popd
-
-# libtool -- requires: m4
-pushd libtool*
-  ./configure --disable-dependency-tracking --prefix $INSTALLROOT --enable-ltdl-install
-  make ${JOBS+-j $JOBS}
-  make install
-  hash -r
-popd
-
-# Do not judge me. I am simply trying to float.
-# Apparently slc6 needs a different order compared
-# to the rest.
-case $ARCHITECTURE in
-  slc6*|ubuntu14*)
-    # automake -- requires: m4, autoconf, gettext
-    pushd automake*
-      $USE_AUTORECONF && [ -e bootstrap ] && sh ./bootstrap
-      ./configure --prefix $INSTALLROOT
-      make MAKEINFO=true ${JOBS+-j $JOBS}
-      make MAKEINFO=true install
-      hash -r
-    popd
-  ;;
-  *) ;;
-esac
-
-
-# gettext -- requires: nothing special
-pushd gettext*
-  $USE_AUTORECONF && autoreconf -ivf
-  ./configure --prefix $INSTALLROOT \
-              --without-xz \
-              --without-bzip2 \
-              --disable-curses \
-              --disable-openmp \
-              --enable-relocatable \
-              --disable-rpath \
-              --disable-nls \
-              --disable-native-java \
-              --disable-acl \
-              --disable-java \
-              --disable-dependency-tracking \
-	      --without-emacs \
-              --disable-silent-rules
-  make ${JOBS+-j $JOBS}
-  make install
-  hash -r
-popd
-
-# Do not judge me. I am simply trying to float.
-case $ARCHITECTURE in
-  slc6*|ubuntu14*) ;;
-  *)
-    # automake -- requires: m4, autoconf, gettext
-    pushd automake*
-      $USE_AUTORECONF && [ -e bootstrap ] && sh ./bootstrap
-      ./configure --prefix $INSTALLROOT
-      make MAKEINFO=true ${JOBS+-j $JOBS}
-      make MAKEINFO=true install
-      hash -r
-    popd
-  ;;
-esac
-
-
-# pkgconfig -- requires: nothing special
-pushd pkg-config*
-  ./configure --disable-debug \
-              --prefix=$INSTALLROOT \
-              --disable-host-tool \
-              --with-internal-glib
-  make ${JOBS+-j $JOBS}
-  make install
-  hash -r
-popd
-
-# Fix perl location, required on /usr/bin/perl
-grep -rlZ -e '^#!.*perl' $INSTALLROOT | \
-  xargs -r -0 -n1 sed -ideleteme -e 's;^#!.*perl;#!/usr/bin/perl;'
-find $INSTALLROOT -name '*deleteme' -delete
-grep -rlZ -e 'exec [^ ]*/perl' $INSTALLROOT | \
-  xargs -r -0 -n1 sed -ideleteme -e 's;exec [^ ]*/perl;exec /usr/bin/perl;g'
-find $INSTALLROOT -name '*deleteme' -delete
+# Meta-package: nothing to build, dependencies provide all tools.
 
 # Pretend we have a modulefile to make the linter happy (don't delete)
 #%Module

--- a/freetype.sh
+++ b/freetype.sh
@@ -5,7 +5,7 @@ source: https://github.com/freetype/freetype
 requires:
   - zlib
 build_requires:
-  - "autotools:(slc6|slc7)"
+  - autotools
   - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |

--- a/gcc-toolchain.sh
+++ b/gcc-toolchain.sh
@@ -5,7 +5,7 @@ source: https://github.com/alisw/gcc-toolchain
 prepend_path:
   "LD_LIBRARY_PATH": "$GCC_TOOLCHAIN_ROOT/lib64"
 build_requires:
-  - "autotools:(slc6|slc7)"
+  - autotools
   - yacc-like
   - make
   - alibuild-recipe-tools

--- a/gettext.sh
+++ b/gettext.sh
@@ -1,0 +1,43 @@
+package: gettext
+version: "%(tag_basename)s"
+tag: v0.23.1
+source: https://git.savannah.gnu.org/git/gettext.git
+build_requires:
+  - autoconf
+  - automake
+  - libtool
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: .*
+prefer_system_check: |
+  autopoint --version
+---
+#!/bin/bash -e
+rsync -a --delete --exclude '**/.git' --delete-excluded "$SOURCEDIR/" ./
+
+if [[ -x ./bootstrap ]]; then
+  ./bootstrap
+elif [[ -f configure.ac ]]; then
+  autoreconf -ivf
+fi
+
+./configure --prefix="$INSTALLROOT" \
+            --without-xz \
+            --without-bzip2 \
+            --disable-curses \
+            --disable-openmp \
+            --enable-relocatable \
+            --disable-rpath \
+            --disable-nls \
+            --disable-native-java \
+            --disable-acl \
+            --disable-java \
+            --disable-dependency-tracking \
+            --without-emacs \
+            --disable-silent-rules
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/gsl.sh
+++ b/gsl.sh
@@ -5,7 +5,7 @@ source: https://github.com/alisw/gsl
 requires:
   - GCC-Toolchain
 build_requires:
-  - "autotools:(slc6|slc7)"
+  - autotools
   - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |

--- a/help2man.sh
+++ b/help2man.sh
@@ -1,0 +1,23 @@
+package: help2man
+version: "1.49.3"
+build_requires:
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: .*
+prefer_system_check: |
+  help2man --version
+---
+#!/bin/bash -e
+
+# help2man has no public git repo; download release tarball from GNU FTP
+curl -sLO "https://ftp.gnu.org/gnu/help2man/help2man-${PKGVERSION}.tar.xz"
+tar xf "help2man-${PKGVERSION}.tar.xz"
+cd "help2man-${PKGVERSION}"
+
+./configure --prefix="$INSTALLROOT"
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/libtool.sh
+++ b/libtool.sh
@@ -1,0 +1,31 @@
+package: libtool
+version: "%(tag_basename)s"
+tag: v2.5.4
+source: https://git.savannah.gnu.org/git/libtool.git
+requires:
+  - m4
+build_requires:
+  - autoconf
+  - automake
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: .*
+prefer_system_check: |
+  libtool --version
+---
+#!/bin/bash -e
+rsync -a --delete --exclude '**/.git' --delete-excluded "$SOURCEDIR/" ./
+
+if [[ -x ./bootstrap ]]; then
+  ./bootstrap
+elif [[ -f configure.ac ]]; then
+  autoreconf -ivf
+fi
+
+./configure --disable-dependency-tracking --prefix="$INSTALLROOT" --enable-ltdl-install
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/libxml2.sh
+++ b/libxml2.sh
@@ -2,7 +2,7 @@ package: libxml2
 version: "%(tag_basename)s"
 tag: v2.9.3
 build_requires:
-  - "autotools:(slc6|slc7)"
+  - autotools
   - zlib
   - GCC-Toolchain
   - alibuild-recipe-tools

--- a/m4.sh
+++ b/m4.sh
@@ -1,0 +1,27 @@
+package: m4
+version: "%(tag_basename)s"
+tag: v1.4.19
+source: https://git.savannah.gnu.org/git/m4.git
+build_requires:
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: .*
+prefer_system_check: |
+  m4 --version
+---
+#!/bin/bash -e
+rsync -a --delete --exclude '**/.git' --delete-excluded "$SOURCEDIR/" ./
+
+if [[ -x ./bootstrap ]]; then
+  ./bootstrap
+elif [[ -f configure.ac ]]; then
+  autoreconf -ivf
+fi
+
+./configure --disable-dependency-tracking --prefix="$INSTALLROOT"
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/photospp.sh
+++ b/photospp.sh
@@ -8,7 +8,7 @@ requires:
   - pythia
   - Tauolapp
 build_requires:
-  - "autotools:(slc6|slc7)"
+  - autotools
   - alibuild-recipe-tools
 prefer_system_check: |
   #!/bin/bash -e

--- a/pkg-config.sh
+++ b/pkg-config.sh
@@ -1,0 +1,28 @@
+package: pkg-config
+version: "%(tag_basename)s"
+tag: pkg-config-0.29.2
+source: https://gitlab.freedesktop.org/pkg-config/pkg-config.git
+build_requires:
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: .*
+prefer_system_check: |
+  pkg-config --version
+---
+#!/bin/bash -e
+rsync -a --delete --exclude '**/.git' --delete-excluded "$SOURCEDIR/" ./
+
+if [[ -f configure.ac ]] && ! [[ -f configure ]]; then
+  autoreconf -ivf
+fi
+
+./configure --disable-debug \
+            --prefix="$INSTALLROOT" \
+            --disable-host-tool \
+            --with-internal-glib
+make ${JOBS+-j $JOBS}
+make install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/uuid.sh
+++ b/uuid.sh
@@ -4,7 +4,7 @@ tag: alice/v2.27.1
 source: https://github.com/alisw/uuid
 build_requires:
   - GCC-Toolchain
-  - "autotools:(slc6|slc7)"
+  - autotools
 prepend_path:
   PKG_CONFIG_PATH: "$UUID_ROOT/share/pkgconfig"
 ---


### PR DESCRIPTION
Split the monolithic autotools recipe (sourced from github.com/alisw/autotools) into individual recipes pointing to upstream repositories:

- m4 v1.4.19 from git.savannah.gnu.org
- autoconf v2.72 from git.savannah.gnu.org (was 2.69)
- automake v1.17 from git.savannah.gnu.org (was 1.16.2)
- libtool v2.5.4 from git.savannah.gnu.org (was 2.4.6)
- gettext v0.23.1 from git.savannah.gnu.org (was 0.20.1)
- help2man 1.49.3 from ftp.gnu.org (was 1.43.2, no public git repo)
- pkg-config 0.29.2 from gitlab.freedesktop.org

The autotools recipe becomes a meta-package depending on all components. All recipes prefer system packages on all architectures.

Also simplify "autotools:(slc6|slc7)" to "autotools" in downstream recipes (gsl, photospp, libxml2, gcc-toolchain, freetype, uuid) since the SLC5/SLC6 architecture filters are no longer relevant.