### PR TITLE
Add tag fields to 5 recipes for Renovate tracking

### DIFF
--- a/eigen3.sh
+++ b/eigen3.sh
@@ -1,5 +1,6 @@
 package: Eigen3
-version: 3.4.0
+version: "%(tag_basename)s"
+tag: 3.4.0
 source: https://gitlab.com/libeigen/eigen.git
 prefer_system: .*
 prefer_system_check: |

--- a/genfit.sh
+++ b/genfit.sh
@@ -1,5 +1,6 @@
 package: GenFit
-version: 02-03-00
+version: "%(tag_basename)s"
+tag: 02-03-00
 source: https://github.com/GenFit/GenFit
 requires:
   - ROOT

--- a/libffi.sh
+++ b/libffi.sh
@@ -1,5 +1,6 @@
 package: libffi
-version: v3.2.1
+version: "%(tag_basename)s"
+tag: v3.2.1
 build_requires:
   - autotools
   - alibuild-recipe-tools

--- a/libpng.sh
+++ b/libpng.sh
@@ -1,5 +1,6 @@
 package: libpng
-version: v1.6.47
+version: "%(tag_basename)s"
+tag: v1.6.47
 requires:
   - zlib
 build_requires:

--- a/xercesc.sh
+++ b/xercesc.sh
@@ -1,5 +1,6 @@
 package: XercesC
-version: v3.3.0
+version: "%(tag_basename)s"
+tag: v3.3.0
 source: https://github.com/apache/xerces-c
 build_requires:
   - GCC-Toolchain


### PR DESCRIPTION
## Summary
- Add explicit `tag:` fields to eigen3, genfit, libffi, libpng, and xercesc recipes
- Switch `version:` from hardcoded values to `%(tag_basename)s` (derived from tag)
- Enables Renovate (PR #235) to detect and propose upstream version updates for these packages