### PR TITLE
Fix Renovate regex patterns not matching dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "matchStringsStrategy": "combination",
       "matchStrings": [
         "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
-        "source:\\s*https://github\\.com/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*$"
+        "source:\\s*https://github\\.com/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*\\n"
       ],
       "datasourceTemplate": "github-tags"
     },
@@ -22,7 +22,7 @@
       "matchStringsStrategy": "combination",
       "matchStrings": [
         "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
-        "source:\\s*https://gitlab\\.cern\\.ch/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*$"
+        "source:\\s*https://gitlab\\.cern\\.ch/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*\\n"
       ],
       "datasourceTemplate": "gitlab-tags",
       "registryUrlTemplate": "https://gitlab.cern.ch"
@@ -34,7 +34,7 @@
       "matchStringsStrategy": "combination",
       "matchStrings": [
         "tag:\\s*\"?(?<currentValue>[^\"\\s\\n]+)\"?",
-        "source:\\s*https://gitlab\\.com/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*$"
+        "source:\\s*https://gitlab\\.com/(?<packageName>[^/\\s]+/[^\\s]+?)(?:\\.git)?\\s*\\n"
       ],
       "datasourceTemplate": "gitlab-tags",
       "registryUrlTemplate": "https://gitlab.com"


### PR DESCRIPTION
## Summary
- Replace `\s*$` with `\s*\n` in all three source regex patterns
- Renovate's regex engine doesn't apply the JavaScript multiline (`m`) flag, so `$` matches end-of-file rather than end-of-line, causing all `source:` patterns to silently fail
- Verified with Node.js that `\n` correctly matches without needing the `m` flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve recipe tag update detection across all supported repository platforms and sources. Refined matching patterns to more robustly handle trailing whitespace in recipe identifiers, ensuring consistent and reliable processing of dependency updates when syncing recipes from GitHub, GitLab CERN, and GitLab.com.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->