### PR TITLE
fix(evtgen): use TAUOLAPP_ROOT in relocated CMake targets

### DIFF
--- a/evtgen.sh
+++ b/evtgen.sh
@@ -46,7 +46,7 @@ if [ -f "$TARGETS_CMAKE" ]; then
     [ -n "$HEPMC3_ROOT" ]   && sed -i "s|${HEPMC3_ROOT}|\$ENV{HEPMC3_ROOT}|g"     "$TARGETS_CMAKE"
     [ -n "$PYTHIA_ROOT" ]   && sed -i "s|${PYTHIA_ROOT}|\$ENV{PYTHIA_ROOT}|g"     "$TARGETS_CMAKE"
     [ -n "$PHOTOSPP_ROOT" ] && sed -i "s|${PHOTOSPP_ROOT}|\$ENV{PHOTOSPP_ROOT}|g" "$TARGETS_CMAKE"
-    [ -n "$TAUOLAPP_ROOT" ] && sed -i "s|${TAUOLAPP_ROOT}|\$ENV{TAUOLA_ROOT}|g" "$TARGETS_CMAKE"
+    [ -n "$TAUOLAPP_ROOT" ] && sed -i "s|${TAUOLAPP_ROOT}|\$ENV{TAUOLAPP_ROOT}|g" "$TARGETS_CMAKE"
 fi
 
 # Modulefile


### PR DESCRIPTION
The relocation sed introduced in 2ca61a57 rewrites the baked-in Tauolapp prefix in share/EvtGen/cmake/EvtGenTargets.cmake to $ENV{TAUOLA_ROOT}. That name is only set by the Tauolapp modulefile; alibuild's etc/profile.d/init.sh (which the build environment sources) exports TAUOLAPP_ROOT, derived from the package name. As a result, consumers like FairShip see an empty expansion and CMake aborts with:

    Imported target "EvtGen::EvtGenExternal" includes non-existent path
      "/include"
    in its INTERFACE_INCLUDE_DIRECTORIES.

Use $ENV{TAUOLAPP_ROOT} to match the variable alibuild actually exports, matching the pattern already used for HEPMC3_ROOT, PYTHIA_ROOT and PHOTOSPP_ROOT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation path handling to ensure builds work correctly when relocated to different system environments.
  * Corrected dependency configuration references during the build process to improve compatibility across various deployment scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/248)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->