### PR TITLE
fix(zlib): bump to upstream madler/zlib v1.3.1

### DIFF
--- a/zlib.sh
+++ b/zlib.sh
@@ -1,7 +1,7 @@
 package: zlib
 version: "%(tag_basename)s"
-tag: v1.2.8
-source: https://github.com/star-externals/zlib
+tag: v1.3.1
+source: https://github.com/madler/zlib.git
 build_requires:
   - GCC-Toolchain
   - alibuild-recipe-tools


### PR DESCRIPTION
aegir's transitive Geant4 dependency requires zlib >= 1.2.11; the recipe pinned a 2013-vintage fork (star-externals/zlib v1.2.8). Moves source to upstream madler/zlib at the current stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zlib to version 1.3.1
  * Updated package source to use the official upstream repository

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/255)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->