### PR TITLE
fix(libxml2): force gnu17 dialect for GCC 15

### DIFF
--- a/libxml2.sh
+++ b/libxml2.sh
@@ -21,6 +21,12 @@ prefer_system_check: |
 #!/bin/sh
 echo "Building ALICE libxml. To avoid this install libxml development package."
 rsync -a $SOURCEDIR/ ./
+
+# libxml2 v2.9.3 has K&R-style empty () declarations in threads.c that GCC 15
+# rejects under its default C23 dialect. Force gnu17 until the recipe is bumped
+# to a C23-clean upstream release.
+export CFLAGS="${CFLAGS} -std=gnu17"
+
 autoreconf -i
 ./configure --disable-static \
             --prefix=$INSTALLROOT \


### PR DESCRIPTION
libxml2 v2.9.3's threads.c uses K&R-style empty-paren function declarations that GCC 15 rejects under its default C23 dialect (which treats () as (void)). Inject -std=gnu17 so the existing source remains buildable until the recipe is bumped to a C23-clean upstream release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved build failures when using GCC 15 by adjusting compiler configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/256)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->