### PR TITLE
feat: update ROOT to v6-38-04 for GCC 16.1.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 * EvtGen: Upgrade to R02-02-03 with HepMC3 support
 * PHOTOSPP, Tauolapp: Build with HepMC3 support
 * APFEL: Upgrade to 3.1.1 and switch to CMake build
+* ROOT: Update to v6-38-04 (bundled LLVM 20) for compatibility with libstdc++ from GCC 16.1.1
 * ROOT, Geant4: Build with Ninja
 * FairLogger: Update to v2.3.1
 * yaml-cpp: Update to 0.8.0, remove obsolete boost dependency

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s%(defaults_upper)s"
-tag: v6-36-08
+tag: v6-38-04
 source: https://github.com/root-project/root
 requires:
   - GSL


### PR DESCRIPTION
## Summary

- Bump ROOT recipe from `v6-36-08` to `v6-38-04` (latest 6.38 stable).
- ROOT 6.36 bundles LLVM 18; its clang does not implement `__builtin_popcountg`, which the libstdc++ in GCC 16.1.1 uses unconditionally in `<bits/atomic_wait.h>`. As a result `rootcling` fails to parse `<atomic>` and dictionary generation breaks (currently surfaces in GenFit).
- ROOT 6.38 bundles LLVM 20, which supports the builtin. The PHLEX-flavour build (`v6-38-02PHLEX`) already runs with this LLVM locally.

## Test plan

- [ ] `bits build -c shipdist --default release FairShip --force-unknown-architecture` completes successfully.
- [ ] `arch_x86-64/ROOT/latest/bin/rootcling --version` reports LLVM 20.x.
- [ ] GenFit dictionary generation completes without the `__builtin_popcountg` error.
- [ ] Smoke-test a short FairShip macro to catch any ROOT 6.38 API regressions in downstream packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HDF5 support for data management
  * Added GeoModel package for geometry modeling
  * Added nlohmann/json library integration
  * Added Python packages: scipy-stubs, types-tabulate, tzdata

* **Changed**
  * Updated major components: Boost (1.87.0), ROOT (v6-38-04), Geant4_VMC (v6-7-p1)
  * Optimized build processes and configuration across packages
  * Enhanced build environment variable handling

* **Chores**
  * Updated CHANGELOG with new packages and version information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/259)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->