### PR TITLE
fix: bump log4cpp to 1.1.6 for modern GCC compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 ## Unreleased
 
+### Fixed
+
+* log4cpp: Bump to upstream stable 1.1.6 to fix build on GCC 13+
+  (missing `#include <ctime>` in DailyRollingFileAppender.hh)
+
 ## [26.04](https://github.com/ShipSoft/shipdist/tree/26.04)
 
 ### Added

--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -1,5 +1,6 @@
 package: log4cpp
-version: 1b9f8f7c031d6947c7468d54bc1da4b2f414558d
+version: "1.1.6"
+tag: "REL_1.1.6_Mar_12_2026"
 source: https://git.code.sf.net/p/log4cpp/codegit
 requires:
   - GCC-Toolchain

--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -16,6 +16,9 @@ prefer_system_check: |
 ---
 #!/bin/bash -ex
 rsync -a $SOURCEDIR/* .
+# automake's default GNU strictness requires a top-level README;
+# the 1.1.6 tarball ships only README.md.
+cp -f README.md README
 ./autogen.sh
 ./configure          --prefix=$INSTALLROOT  \
 		     --enable-shared


### PR DESCRIPTION
The pinned 2014-era git snapshot fails to build on GCC 13+ / libstdc++ because include/log4cpp/DailyRollingFileAppender.hh declares a 'struct tm _logsTime' member without an explicit '#include <ctime>'. Upstream stable 1.1.6 (12 Mar 2026) adds the missing include.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded log4cpp to v1.1.6 to resolve build/compilation issues with GCC 13+.

* **Chores**
  * Updated package version and release tag metadata for v1.1.6.
  * Ensured packaging includes a top-level README to produce a compliant release tarball.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->