### PR TITLE
fix: bump XRootD to v6.0.1 for modern GCC compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 * APFEL: Upgrade to 3.1.1 and switch to CMake build
 * ROOT: Update to v6-38-04 (bundled LLVM 20) for compatibility with libstdc++ from GCC 16.1.1
 * ROOT, Geant4: Build with Ninja
+* XRootD: Update to v6.0.1 (was v5.8.4) so the build no longer trips GCC 13+'s
+  -Werror=null-dereference on the bundled tinyxml (upstream demoted it to a
+  plain warning from v5.9.0 onwards). Renamed ENABLE_XRDCLHTTP to ENABLE_HTTP
+  to match v6.0's CMake option layout.
 * FairLogger: Update to v2.3.1
 * yaml-cpp: Update to 0.8.0, remove obsolete boost dependency
 * FairShip: Build with Ninja

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -1,6 +1,6 @@
 package: XRootD
 version: "%(tag_basename)s"
-tag: "v5.8.4"
+tag: "v6.0.1"
 source: https://github.com/xrootd/xrootd
 requires:
   - OpenSSL
@@ -54,7 +54,7 @@ cmake "${BUILDDIR}"                                                   \
       -DENABLE_KRB5=ON \
       -DENABLE_FUSE=OFF                                               \
       -DENABLE_VOMS=OFF                                               \
-      -DENABLE_XRDCLHTTP=OFF                                          \
+      -DENABLE_HTTP=OFF                                               \
       -DENABLE_READLINE=OFF                                           \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \
       ${OPENSSL_ROOT:+-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT}               \

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -18,7 +18,7 @@ prepend_path:
 #!/bin/bash -e
 
 XROOTD_PYTHON=""
-[[ -e ${SOURCEDIR}/bindings ]] && XROOTD_PYTHON=True;
+[[ -e ${SOURCEDIR}/bindings || -e ${SOURCEDIR}/python ]] && XROOTD_PYTHON=True;
 PYTHON_EXECUTABLE=$(/usr/bin/env python3 -c 'import sys; print(sys.executable)')
 PYTHON_VER=$( ${PYTHON_EXECUTABLE} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' )
 
@@ -106,9 +106,9 @@ mkdir -p "$MODULEDIR"
 
 alibuild-generate-module --bin --lib > "$MODULEFILE"
 
-cat >> "$MODULEFILE" <<EoF
-if { $XROOTD_PYTHON } {
-  prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
-  module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}
-}
+if [[ "$XROOTD_PYTHON" == "True" ]]; then
+  cat >> "$MODULEFILE" <<EoF
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+${PYTHON_REVISION:+module load Python/$PYTHON_VERSION-$PYTHON_REVISION}
 EoF
+fi


### PR DESCRIPTION
The pinned v5.8.4 fails on GCC 13+ because cmake/XRootDOSDefs.cmake promotes -Wnull-dereference to a hard error, which the bundled tinyxml trips. Upstream demoted the flag to a plain warning in v5.9.0 and the same fix is present in v6.0.1.

Also rename the now-removed ENABLE_XRDCLHTTP cache variable to its v6.0 successor ENABLE_HTTP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed log4cpp compatibility issue

* **Changed**
  * Upgraded XRootD to v6.0.1 (from v5.8.4)
  * Updated CMake configuration layout to match v6.0
  * Improved handling of Python bindings during build/install detection
  * Enhanced modulefile generation to set PYTHONPATH and optionally load the Python module for runtime use

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->