### PR TITLE
fix: derive version from tag via %(tag_basename)s

### DIFF
--- a/alibuild-recipe-tools.sh
+++ b/alibuild-recipe-tools.sh
@@ -1,5 +1,5 @@
 package: alibuild-recipe-tools
-version: "0.2.5"
+version: "%(tag_basename)s"
 tag: "v0.3.0"
 source: https://github.com/alisw/alibuild-recipe-tools
 ---

--- a/apfel.sh
+++ b/apfel.sh
@@ -1,5 +1,5 @@
 package: apfel
-version: 3.1.1
+version: "%(tag_basename)s"
 tag: 3.1.1
 source: https://github.com/scarrazza/apfel.git
 requires:

--- a/fairroot.sh
+++ b/fairroot.sh
@@ -1,5 +1,5 @@
 package: FairRoot
-version: "v19.0.0"
+version: "%(tag_basename)s"
 tag: "v19.0.1"
 source: https://github.com/FairRootGroup/FairRoot
 requires:

--- a/fairship.sh
+++ b/fairship.sh
@@ -1,5 +1,5 @@
 package: FairShip
-version: master
+version: "%(tag_basename)s"
 tag: master
 source: https://github.com/ShipSoft/FairShip
 requires:

--- a/freetype.sh
+++ b/freetype.sh
@@ -1,5 +1,5 @@
 package: FreeType
-version: v2.10.1
+version: "%(tag_basename)s"
 tag: VER-2-10-1
 source: https://github.com/freetype/freetype
 requires:

--- a/genie.sh
+++ b/genie.sh
@@ -1,5 +1,5 @@
 package: GENIE
-version: v3.6.2
+version: "%(tag_basename)s"
 tag: R-3_06_02
 source: https://github.com/GENIE-MC/Generator.git
 requires:

--- a/googletest.sh
+++ b/googletest.sh
@@ -1,5 +1,5 @@
 package: googletest
-version: "1.17.0"
+version: "%(tag_basename)s"
 tag: v1.17.0
 source: https://github.com/google/googletest
 build_requires:

--- a/gsl.sh
+++ b/gsl.sh
@@ -1,5 +1,5 @@
 package: GSL
-version: "v2.8"
+version: "%(tag_basename)s"
 tag: "v2.8"
 source: https://github.com/alisw/gsl
 requires:

--- a/log4cpp.sh
+++ b/log4cpp.sh
@@ -1,5 +1,5 @@
 package: log4cpp
-version: "1.1.6"
+version: "%(tag_basename)s"
 tag: "REL_1.1.6_Mar_12_2026"
 source: https://git.code.sf.net/p/log4cpp/codegit
 requires:

--- a/npdb-client.sh
+++ b/npdb-client.sh
@@ -1,5 +1,5 @@
 package: npdb-client
-version: "0.2.0"
+version: "%(tag_basename)s"
 tag: "0.2.0"
 source: https://gitlab.cern.ch/ship/computing/npdb
 build_requires:

--- a/openssl.sh
+++ b/openssl.sh
@@ -23,15 +23,8 @@ prepend_path:
 #!/bin/bash -e
 
 rsync -av --delete --exclude="**/.git" "$SOURCEDIR/" .
-case ${PKG_VERSION} in
-  v1.1*)
-    OPTS=""
-    OPENSSLDIRPREFIX="" ;;
-  *)
-    OPTS="no-krb5"
-    OPENSSLDIRPREFIX="etc/ssl"
-  ;;
-esac
+OPTS=""
+OPENSSLDIRPREFIX=""
 
 ./config --prefix="$INSTALLROOT"                   \
          --openssldir="$INSTALLROOT/$OPENSSLDIRPREFIX"       \

--- a/openssl.sh
+++ b/openssl.sh
@@ -1,5 +1,5 @@
 package: OpenSSL
-version: v1.1.1m
+version: "%(tag_basename)s"
 tag: OpenSSL_1_1_1m
 source: https://github.com/openssl/openssl
 prefer_system: (?!slc5|slc6)

--- a/pcre.sh
+++ b/pcre.sh
@@ -1,5 +1,5 @@
 package: PCRE
-version: master
+version: "%(tag_basename)s"
 tag: master
 source: https://github.com/ktf/pcre
 prefer_system: (?!slc5)

--- a/swig.sh
+++ b/swig.sh
@@ -1,5 +1,5 @@
 package: SWIG
-version: 3.0.7
+version: "%(tag_basename)s"
 tag: rel-3.0.7
 source: https://github.com/swig/swig
 build_requires:

--- a/tbb.sh
+++ b/tbb.sh
@@ -1,5 +1,5 @@
 package: TBB
-version: "v2021.5.0"
+version: "%(tag_basename)s"
 tag: v2021.5.0
 source: https://github.com/uxlfoundation/oneTBB
 build_requires:

--- a/uuid.sh
+++ b/uuid.sh
@@ -1,5 +1,5 @@
 package: UUID
-version: v2.27.1
+version: "%(tag_basename)s"
 tag: alice/v2.27.1
 source: https://github.com/alisw/uuid
 build_requires:


### PR DESCRIPTION
Standardise recipes that defined tag and version separately to use version: "%(tag_basename)s" instead, preventing them from getting out of sync. This also fixes existing mismatches in fairroot, alibuild-recipe-tools, and googletest.