### PR TITLE
fix(acts,fairship,hepmc3,pcre,rootegpythia6): pin branches

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -1,5 +1,6 @@
 package: acts
 version: shipdist-build
+tag: 7bc78ecd82ff4469dd6f688392539928735a111a
 source: https://github.com/webbjm/acts.git
 requires:
   - ROOT

--- a/fairship.sh
+++ b/fairship.sh
@@ -1,6 +1,6 @@
 package: FairShip
 version: "%(tag_basename)s"
-tag: master
+tag: "26.04"
 source: https://github.com/ShipSoft/FairShip
 requires:
   - pythia

--- a/hepmc3.sh
+++ b/hepmc3.sh
@@ -1,6 +1,6 @@
 package: HepMC3
 version: "%(tag_basename)s"
-tag: master
+tag: e81837df0966975b81448deb9fffd3b52c1dcc8a
 source: https://gitlab.cern.ch/hepmc/HepMC3.git
 requires:
   - ROOT

--- a/pcre.sh
+++ b/pcre.sh
@@ -1,6 +1,6 @@
 package: PCRE
 version: "%(tag_basename)s"
-tag: master
+tag: v8.36
 source: https://github.com/ktf/pcre
 prefer_system: (?!slc5)
 prefer_system_check: |

--- a/rootegpythia6.sh
+++ b/rootegpythia6.sh
@@ -1,6 +1,6 @@
 package: ROOTEGPythia6
 version: "%(tag_basename)s"
-tag: main
+tag: feb7c7eb8d368aee20bf1cb01f1bbfb9cfaeb6b5
 source: https://github.com/luketpickering/ROOTEGPythia6
 requires:
   - ROOT


### PR DESCRIPTION
Replace branch-tracking tags (master/main) with pinned versions for reproducible builds:

- FairShip: master → 26.04
- HepMC3: master → e81837d (post-3.3.1, includes ROOT 6.38 compat)
- PCRE: master → v8.36
- ROOTEGPythia6: main → feb7c7e (no tags available)
- acts: add tag field pinning to 7bc78ec (no tags available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for ACTS, FairShip, HepMC3, PCRE, and ROOTEGPythia6 to pin to specific versions and implement tag-based versioning strategies.
  * These updates ensure reproducible and stable builds by replacing dynamic branch references with fixed version identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->