### PR TITLE
feat(root): update to v6-40-00

### DIFF
--- a/giflib.sh
+++ b/giflib.sh
@@ -1,0 +1,20 @@
+package: giflib
+version: "%(tag_basename)s"
+tag: "6.1.3"
+source: https://git.code.sf.net/p/giflib/code
+build_requires:
+  - GCC-Toolchain
+  - alibuild-recipe-tools
+prefer_system: (?!slc5)
+prefer_system_check: |
+  #!/bin/bash -e
+  printf "#include <gif_lib.h>\n" | c++ -xc++ - -c -M 2>&1
+---
+#!/bin/bash -e
+rsync -a --delete --exclude '**/.git' --delete-excluded $SOURCEDIR/ ./
+make ${JOBS:+-j$JOBS}
+make PREFIX=$INSTALLROOT install
+
+# Modulefile
+mkdir -p "$INSTALLROOT/etc/modulefiles"
+alibuild-generate-module --lib > "$INSTALLROOT/etc/modulefiles/$PKGNAME"

--- a/gl2ps.sh
+++ b/gl2ps.sh
@@ -1,0 +1,33 @@
+package: gl2ps
+version: "%(tag_basename)s"
+tag: gl2ps_1_4_2
+source: https://gitlab.onelab.info/gl2ps/gl2ps.git
+requires:
+  - opengl
+  - zlib
+  - libpng
+build_requires:
+  - CMake
+  - ninja
+  - alibuild-recipe-tools
+prefer_system: (?!slc5)
+prefer_system_check: |
+  #!/bin/bash -e
+  printf "#include <gl2ps.h>\n" | c++ -xc++ - -c -M 2>&1
+---
+#!/bin/bash -e
+cmake $SOURCEDIR \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  ${ZLIB_ROOT:+-DZLIB_ROOT=$ZLIB_ROOT} \
+  ${LIBPNG_ROOT:+-DPNG_ROOT=$LIBPNG_ROOT}
+
+cmake --build . -- ${JOBS:+-j$JOBS} install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module --lib > "$MODULEFILE"

--- a/root.sh
+++ b/root.sh
@@ -1,6 +1,6 @@
 package: ROOT
 version: "%(tag_basename)s%(defaults_upper)s"
-tag: v6-38-04
+tag: v6-40-00
 source: https://github.com/root-project/root
 requires:
   - GSL
@@ -82,8 +82,6 @@ ${PYTHIA_ROOT:+-Dpythia8=ON}                \
 -Dsoversion=ON                                            \
 -Dshadowpw=OFF                                            \
 -Dbuiltin_vdt=ON                                          \
--Dbuiltin_davix=OFF                                                              \
--Ddavix=OFF                                                                      \
 ${PYTHON_ROOT:+-DPYTHON_EXECUTABLE=$PYTHONHOME/bin/python3} \
 ${PYTHON_ROOT:+-DPython3_ROOT_DIR=$PYTHON_ROOT} \
 -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$GSL_ROOT;$PYTHON_ROOT"

--- a/root.sh
+++ b/root.sh
@@ -14,6 +14,9 @@ requires:
   - XRootD
   - pythia
   - TBB
+  - giflib
+  - zstd
+  - gl2ps
 build_requires:
   - CMake
   - libxml2
@@ -84,7 +87,9 @@ ${PYTHIA_ROOT:+-Dpythia8=ON}                \
 -Dbuiltin_vdt=ON                                          \
 ${PYTHON_ROOT:+-DPYTHON_EXECUTABLE=$PYTHONHOME/bin/python3} \
 ${PYTHON_ROOT:+-DPython3_ROOT_DIR=$PYTHON_ROOT} \
--DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$GSL_ROOT;$PYTHON_ROOT"
+${GIFLIB_ROOT:+-DGIF_INCLUDE_DIR=$GIFLIB_ROOT/include} \
+${GIFLIB_ROOT:+-DGIF_LIBRARY=$GIFLIB_ROOT/lib/libgif.so} \
+-DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$GSL_ROOT;$PYTHON_ROOT;$ZSTD_ROOT;$GL2PS_ROOT"
 FEATURES="builtin_pcre xml ssl opengl http gdml mathmore ${PYTHIA_ROOT:+pythia8}
     roofit soversion vdt ${XROOTD_ROOT:+xrootd}"
 NO_FEATURES="${FREETYPE_ROOT:+builtin_freetype}"

--- a/zstd.sh
+++ b/zstd.sh
@@ -1,0 +1,30 @@
+package: zstd
+version: "%(tag_basename)s"
+tag: v1.5.6
+source: https://github.com/facebook/zstd
+build_requires:
+  - GCC-Toolchain
+  - CMake
+  - ninja
+  - alibuild-recipe-tools
+prefer_system: (?!slc5)
+prefer_system_check: |
+  #!/bin/bash -e
+  printf "#include <zstd.h>\n" | c++ -xc++ - -c -M 2>&1
+---
+#!/bin/bash -e
+cmake $SOURCEDIR/build/cmake \
+  -G Ninja \
+  -DCMAKE_INSTALL_PREFIX=$INSTALLROOT \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DZSTD_BUILD_TESTS=OFF \
+  -DZSTD_BUILD_PROGRAMS=OFF \
+  -DBUILD_TESTING=OFF
+
+cmake --build . -- ${JOBS:+-j$JOBS} install
+
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+alibuild-generate-module --lib > "$MODULEFILE"


### PR DESCRIPTION
## Summary
- Update ROOT from v6-38-04 to v6-40-00
- Remove `builtin_davix` and `davix` build options, which were [removed upstream](https://root.cern/doc/v640/release-notes.html) in ROOT 6.40

Note: ROOT 6.40 raises the minimum Python version to 3.10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added giflib, gl2ps and zstd packages to the build offerings.
* **Chores**
  * Upgraded ROOT from v6-38-04 to v6-40-00.
  * Expanded ROOT's required dependencies and updated build wiring (Python discovery, explicit GIF/ZSTD/GL2PS paths).
  * Removed previous Davix-related build flags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->