### PR TITLE
fix(yaml-cpp): bump to 0.9.0 for modern GCC compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it
 
 * log4cpp: Bump to upstream stable 1.1.6 to fix build on GCC 13+
   (missing `#include <ctime>` in DailyRollingFileAppender.hh)
+* yaml-cpp: Bump to upstream 0.9.0 to fix build on GCC 13+
+  (missing `#include <cstdint>` in `src/emitterutils.cpp`)
 
 ## [26.04](https://github.com/ShipSoft/shipdist/tree/26.04)
 

--- a/yaml-cpp.sh
+++ b/yaml-cpp.sh
@@ -1,18 +1,20 @@
 package: yaml-cpp
 version: "%(tag_basename)s"
-tag: 0.8.0
+tag: yaml-cpp-0.9.0
 source: https://github.com/jbeder/yaml-cpp
 build_requires:
   - CMake
   - alibuild-recipe-tools
 prefer_system: (?!slc5)
 prefer_system_check: |
+  #!/bin/bash -e
+  REQUESTED_VERSION=${REQUESTED_VERSION#yaml-cpp-}
   REQUESTED_VERSION=${REQUESTED_VERSION#v}
   pkg-config --atleast-version=$REQUESTED_VERSION yaml-cpp &&
     printf "#include \"yaml-cpp/yaml.h\"\n" |
     c++ -std=c++17 -xc++ - -c -o /dev/null
 ---
-#!/bin/sh
+#!/bin/bash -e
 
 cmake $SOURCEDIR                                         \
   -DCMAKE_INSTALL_PREFIX:PATH="$INSTALLROOT"             \


### PR DESCRIPTION
The pinned 0.8.0 tarball fails to build on GCC 13+ / libstdc++ because src/emitterutils.cpp uses uint16_t and uint32_t without including <cstdint>; the transitive include path that previously provided it was removed in newer libstdc++ releases. Upstream 0.9.0 (4 Feb 2026) adds the missing #include directly.

The new upstream tag is `yaml-cpp-0.9.0` (prefixed), unlike the bare `0.8.0` it replaces. Strip the `yaml-cpp-` prefix inside prefer_system_check so pkg-config --atleast-version still receives a clean semver. Keep `version: "%(tag_basename)s"` so the tag remains the single source of truth.

Related #234.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bumped yaml-cpp to 0.9.0 to fix build failures with newer GCC toolchains (GCC 13+), restoring reliable compilation on affected environments.

* **Chores**
  * Updated packaging/recipe checks and scripts to recognize and require the newer yaml-cpp release, improving version detection and build reproducibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->