### PR TITLE
fix: use versioned Python sitepackages paths instead of symlinks

### DIFF
--- a/alibuild.sh
+++ b/alibuild.sh
@@ -18,7 +18,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import alibuild_helpers; print(alibuild_helpers.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$ALIBUILD_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$ALIBUILD_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
   PATH: "$ALIBUILD_ROOT/bin"
 ---
 #!/bin/bash -e
@@ -28,8 +28,6 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "alibuild==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 # Move scripts installed into the target to the bin directory
 mkdir -p "$INSTALLROOT/bin"
 mv "$TARGET/bin"/* "$INSTALLROOT/bin/"
@@ -38,6 +36,6 @@ mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 prepend-path PATH \$PKG_ROOT/bin
 EOF

--- a/bitsorg.sh
+++ b/bitsorg.sh
@@ -16,7 +16,7 @@ build_requires:
 prefer_system_check: |
   python3 -c 'import alibuild_helpers' || exit 1
 prepend_path:
-  PYTHONPATH: "$BITSORG_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$BITSORG_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
   PATH: "$BITSORG_ROOT/bin"
 ---
 #!/bin/bash -e
@@ -26,8 +26,6 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "bitsorg==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 # Move scripts installed into the target to the bin directory
 mkdir -p "$INSTALLROOT/bin"
 mv "$TARGET/../../../bin"/* "$INSTALLROOT/bin/"
@@ -36,6 +34,6 @@ mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 prepend-path PATH \$PKG_ROOT/bin
 EOF

--- a/python-awkward-cpp.sh
+++ b/python-awkward-cpp.sh
@@ -14,7 +14,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import awkward_cpp; print(awkward_cpp.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_AWKWARD_CPP_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_AWKWARD_CPP_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -23,11 +23,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "awkward-cpp==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-awkward.sh
+++ b/python-awkward.sh
@@ -17,7 +17,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import awkward; print(awkward.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_AWKWARD_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_AWKWARD_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -26,11 +26,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "awkward==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-certifi.sh
+++ b/python-certifi.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import certifi; print(certifi.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_CERTIFI_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_CERTIFI_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "certifi==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-charset-normalizer.sh
+++ b/python-charset-normalizer.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import charset_normalizer; print(charset_normalizer.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_CHARSET_NORMALIZER_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_CHARSET_NORMALIZER_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "charset_normalizer==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-contourpy.sh
+++ b/python-contourpy.sh
@@ -14,7 +14,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import contourpy; print(contourpy.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_CONTOURPY_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_CONTOURPY_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -23,11 +23,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "contourpy==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-cramjam.sh
+++ b/python-cramjam.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import cramjam; print(cramjam.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_CRAMJAM_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_CRAMJAM_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "cramjam==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-cycler.sh
+++ b/python-cycler.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import cycler; print(cycler.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_CYCLER_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_CYCLER_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "cycler==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-dateutil.sh
+++ b/python-dateutil.sh
@@ -14,7 +14,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import dateutil; print(dateutil.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_DATEUTIL_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_DATEUTIL_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -23,11 +23,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "python-dateutil==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-distro.sh
+++ b/python-distro.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import distro; print(distro.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_DISTRO_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_DISTRO_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "distro==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-execnet.sh
+++ b/python-execnet.sh
@@ -11,7 +11,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import execnet; print(execnet.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_EXECNET_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_EXECNET_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -20,11 +20,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "execnet==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-fonttools.sh
+++ b/python-fonttools.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import fontTools; print(fontTools.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_FONTTOOLS_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_FONTTOOLS_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "fonttools==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-fsspec.sh
+++ b/python-fsspec.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import fsspec; print(fsspec.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_FSSPEC_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_FSSPEC_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "fsspec==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-idna.sh
+++ b/python-idna.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import idna; print(idna.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_IDNA_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_IDNA_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "idna==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-iniconfig.sh
+++ b/python-iniconfig.sh
@@ -11,7 +11,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import iniconfig; print(iniconfig.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_INICONFIG_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_INICONFIG_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -20,11 +20,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "iniconfig==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-jinja2.sh
+++ b/python-jinja2.sh
@@ -14,7 +14,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import jinja2; print(jinja2.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_JINJA2_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_JINJA2_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -23,11 +23,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "Jinja2==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-kiwisolver.sh
+++ b/python-kiwisolver.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import kiwisolver; print(kiwisolver.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_KIWISOLVER_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_KIWISOLVER_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "kiwisolver==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-markupsafe.sh
+++ b/python-markupsafe.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import markupsafe; print(markupsafe.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_MARKUPSAFE_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_MARKUPSAFE_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "MarkupSafe==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-matplotlib.sh
+++ b/python-matplotlib.sh
@@ -24,7 +24,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import matplotlib; print(matplotlib.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_MATPLOTLIB_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_MATPLOTLIB_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -33,11 +33,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "matplotlib==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-numpy.sh
+++ b/python-numpy.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import numpy; print(numpy.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_NUMPY_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_NUMPY_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "numpy==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-packaging.sh
+++ b/python-packaging.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import packaging; print(packaging.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PACKAGING_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PACKAGING_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "packaging==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-pandas.sh
+++ b/python-pandas.sh
@@ -15,7 +15,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import pandas; print(pandas.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PANDAS_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PANDAS_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -24,11 +24,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pandas==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-pillow.sh
+++ b/python-pillow.sh
@@ -15,7 +15,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import PIL; print(PIL.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PILLOW_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PILLOW_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -24,11 +24,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pillow==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-pluggy.sh
+++ b/python-pluggy.sh
@@ -11,7 +11,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import pluggy; print(pluggy.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PLUGGY_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PLUGGY_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -20,11 +20,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pluggy==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-pygments.sh
+++ b/python-pygments.sh
@@ -11,7 +11,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import pygments; print(pygments.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYGMENTS_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PYGMENTS_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -20,11 +20,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pygments==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-pyparsing.sh
+++ b/python-pyparsing.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import pyparsing; print(pyparsing.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYPARSING_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PYPARSING_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pyparsing==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-pytest-xdist.sh
+++ b/python-pytest-xdist.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import xdist; print(xdist.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYTEST_XDIST_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PYTEST_XDIST_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest-xdist==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-pytest.sh
+++ b/python-pytest.sh
@@ -15,7 +15,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import pytest; print(pytest.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYTEST_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PYTEST_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
   PATH: "$PYTHON_PYTEST_ROOT/bin"
 ---
 #!/bin/bash -e
@@ -24,7 +24,6 @@ TARGET="$INSTALLROOT/lib/python$pyver/site-packages"
 mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "pytest==$PKGVERSION"
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
 
 # Install stable entrypoint wrappers that always use the loaded aliBuild Python.
 mkdir -p "$INSTALLROOT/bin"
@@ -39,6 +38,6 @@ mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module --bin > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 prepend-path PATH \$PKG_ROOT/bin
 EOF

--- a/python-pyyaml.sh
+++ b/python-pyyaml.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import yaml; print(yaml.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_PYYAML_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_PYYAML_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "PyYAML==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-requests.sh
+++ b/python-requests.sh
@@ -17,7 +17,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import requests; print(requests.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_REQUESTS_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_REQUESTS_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -26,11 +26,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "requests==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-scipy.sh
+++ b/python-scipy.sh
@@ -14,7 +14,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import scipy; print(scipy.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_SCIPY_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_SCIPY_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -23,11 +23,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "scipy==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-six.sh
+++ b/python-six.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import six; print(six.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_SIX_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_SIX_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "six==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-tabulate.sh
+++ b/python-tabulate.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import tabulate; print(tabulate.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_TABULATE_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_TABULATE_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "tabulate==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-uproot.sh
+++ b/python-uproot.sh
@@ -19,7 +19,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import uproot; print(uproot.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_UPROOT_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_UPROOT_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -28,11 +28,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "uproot==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-urllib3.sh
+++ b/python-urllib3.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import urllib3; print(urllib3.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_URLLIB3_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_URLLIB3_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "urllib3==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python-xxhash.sh
+++ b/python-xxhash.sh
@@ -13,7 +13,7 @@ prefer_system_check: |
   SYSTEM_VERSION=$(python3 -c 'import xxhash; print(xxhash.__version__)')
   printf '%s\n%s\n' "$PKGVERSION" "$SYSTEM_VERSION" | sort -V -C
 prepend_path:
-  PYTHONPATH: "$PYTHON_XXHASH_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_XXHASH_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 pyver=$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')
@@ -22,11 +22,9 @@ mkdir -p "$TARGET"
 
 uv pip install --no-deps --no-cache-dir --target="$TARGET" --python="$(command -v python3)" "xxhash==$PKGVERSION"
 
-ln -snf "python$pyver" "$INSTALLROOT/lib/python"
-
 mkdir -p "$INSTALLROOT/etc/modulefiles"
 alibuild-generate-module > "$INSTALLROOT/etc/modulefiles/$PKGNAME"
 cat >> "$INSTALLROOT/etc/modulefiles/$PKGNAME" <<EOF
 set PKG_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 EOF

--- a/python.sh
+++ b/python.sh
@@ -17,7 +17,7 @@ env:
     export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH;
     python -c "import certifi; print(certifi.where())")
   PYTHONHOME: "$PYTHON_ROOT"
-  PYTHONPATH: "$PYTHON_ROOT/lib/python/site-packages"
+  PYTHONPATH: "$PYTHON_ROOT/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 prefer_system: "(?!slc5|ubuntu)"
 prefer_system_check: |
     #!/bin/bash -e
@@ -105,10 +105,6 @@ env PATH="$INSTALLROOT/bin:$PATH" \
     PYTHONHOME="$INSTALLROOT" \
     python3 -m pip install 'certifi==2022.12.7'
 
-# Uniform Python library path
-pushd "$INSTALLROOT/lib" || exit
-  ln -nfs python* python
-popd || exit
 
 # Remove useless stuff
 rm -rvf "$INSTALLROOT"/share "$INSTALLROOT"/lib/python*/test
@@ -117,6 +113,8 @@ find "$INSTALLROOT"/lib/python* \
      -exec rm -rvf '{}' \;
 
 
+pyver=$("$INSTALLROOT/bin/python3" -c 'import sysconfig; print(sysconfig.get_python_version())')
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
@@ -124,7 +122,7 @@ mkdir -p "$MODULEDIR"
 alibuild-generate-module --bin --lib > "$MODULEFILE"
 cat >> "$MODULEFILE" <<EoF
 setenv PYTHONHOME \$PKG_ROOT
-prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+prepend-path PYTHONPATH \$PKG_ROOT/lib/python$pyver/site-packages
 if { [module-info mode load] } {
   setenv SSL_CERT_FILE  [exec \$PKG_ROOT/bin/python3 -c "import certifi; print(certifi.where())"]
 }

--- a/xrootd.sh
+++ b/xrootd.sh
@@ -13,7 +13,7 @@ build_requires:
   - UUID
   - alibuild-recipe-tools
 prepend_path:
-  PYTHONPATH: "${XROOTD_ROOT}/lib/python/site-packages"
+  PYTHONPATH: "${XROOTD_ROOT}/lib/python$(python3 -c 'import sysconfig; print(sysconfig.get_python_version())')/site-packages"
 ---
 #!/bin/bash -e
 
@@ -82,11 +82,9 @@ if [[ "$XROOTD_PYTHON" == "True" ]]; then
 
     pushd lib
     if [ -d ../lib64/python${PYTHON_VER} ]; then
-      ln -s ../lib64/python${PYTHON_VER} python
-    elif [[ -d python${PYTHON_VER} ]]; then
-      ln -s python${PYTHON_VER} python
+      mv ../lib64/python${PYTHON_VER} .
     fi
-    [[ ! -e python ]] && echo "NO PYTHON SYMLINK CREATED in: $(pwd -P)"
+    [[ ! -d python${PYTHON_VER} ]] && echo "NO PYTHON${PYTHON_VER} DIRECTORY in: $(pwd -P)"
     popd  # get back from lib
 
     popd  # get back from INSTALLROOT
@@ -94,7 +92,7 @@ if [[ "$XROOTD_PYTHON" == "True" ]]; then
     # Print found XRootD python bindings
     # just run the the command as this is under "bash -e"
     echo -ne ">>>>>>   Found XRootD python bindings: "
-    LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
+    LD_LIBRARY_PATH="$INSTALLROOT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH" PYTHONPATH="$INSTALLROOT/lib/python${PYTHON_VER}/site-packages${PYTHONPATH:+:}$PYTHONPATH" ${PYTHON_EXECUTABLE} -c 'from XRootD import client as xrd_client;print(f"{xrd_client.__version__}\n{xrd_client.__file__}");'
     echo
 
 fi  # end of PYTHON part
@@ -108,7 +106,7 @@ alibuild-generate-module --bin --lib > "$MODULEFILE"
 
 cat >> "$MODULEFILE" <<EoF
 if { $XROOTD_PYTHON } {
-  prepend-path PYTHONPATH \$PKG_ROOT/lib/python/site-packages
+  prepend-path PYTHONPATH \$PKG_ROOT/lib/python$PYTHON_VER/site-packages
   module load ${PYTHON_REVISION:+Python/$PYTHON_VERSION-$PYTHON_REVISION}
 }
 EoF


### PR DESCRIPTION
## Summary

- Replace the fragile `lib/python` → `lib/python$pyver` symlink with direct use of versioned paths (e.g. `lib/python3.12/site-packages`) across all 39 Python-related recipes
- YAML `prepend_path` now uses command substitution to resolve the Python version dynamically
- Modulefiles embed the versioned path at build time
- Removes all `ln -snf "python$pyver"` symlink creation lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations for numerous Python packages to standardize version-specific site-packages directory handling. Changes affect installation paths, runtime environment setup, and generated module files across the Python package ecosystem. These updates improve path consistency and reliability while eliminating legacy symlink-based fallback mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->