### PR TITLE
fix(rootegpythia6): use external pythia6 instead of builtin

### DIFF
--- a/rootegpythia6.sh
+++ b/rootegpythia6.sh
@@ -4,6 +4,7 @@ tag: feb7c7eb8d368aee20bf1cb01f1bbfb9cfaeb6b5
 source: https://github.com/luketpickering/ROOTEGPythia6
 requires:
   - ROOT
+  - pythia6
   - GCC-Toolchain
 build_requires:
   - CMake
@@ -31,10 +32,21 @@ sed -i \
   -e '/^ROOT_GENERATE_DICTIONARY/i include_directories(${CMAKE_CURRENT_LIST_DIR}/inc)' \
   "$SOURCEDIR/CMakeLists.txt"
 
+# Patch the exported package config so downstream consumers (e.g. FairShip,
+# which has FairRoot's FindPythia6 on CMAKE_MODULE_PATH) get the
+# Pythia6::Pythia6 IMPORTED target that ROOTEGPythia6Targets.cmake links
+# against. FairRoot's FindPythia6 creates a non-namespaced "Pythia6" target;
+# upstream ROOTEGPythia6 expects "Pythia6::Pythia6". Define the namespaced
+# target directly so we don't depend on whichever FindPythia6 module the
+# consumer picks up first.
+sed -i 's|find_package(Pythia6 REQUIRED)|if(NOT TARGET Pythia6::Pythia6)\n  if(NOT DEFINED ENV{PYTHIA6_ROOT} OR NOT EXISTS "$ENV{PYTHIA6_ROOT}/lib/libPythia6.so")\n    message(FATAL_ERROR "ROOTEGPythia6 requires PYTHIA6_ROOT to point to a directory containing lib/libPythia6.so")\n  endif()\n  add_library(Pythia6::Pythia6 SHARED IMPORTED)\n  set_target_properties(Pythia6::Pythia6 PROPERTIES IMPORTED_LOCATION "$ENV{PYTHIA6_ROOT}/lib/libPythia6.so")\nendif()|' \
+  "$SOURCEDIR/cmake/Templates/ROOTEGPythia6Config.cmake.in"
+
 cmake "$SOURCEDIR" \
       -DCMAKE_INSTALL_PREFIX="$INSTALLROOT" \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-      -DROOTEGPythia6_Pythia6_BUILTIN=ON \
+      -DROOTEGPythia6_Pythia6_BUILTIN=OFF \
+      -DPYTHIA6_LIB_DIR="$PYTHIA6_ROOT/lib" \
       -DCMAKE_INSTALL_LIBDIR=lib
 
 cmake --build . ${JOBS:+-j$JOBS}


### PR DESCRIPTION
## Summary
- Disable the builtin Pythia6 in ROOTEGPythia6 (`-DROOTEGPythia6_Pythia6_BUILTIN=OFF`)
- Add `pythia6` as a runtime dependency to use the existing external recipe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and dependencies to enable proper external Pythia6 library integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->