### PR TITLE
fix(rootegpythia6): fix rootmap naming mismatch

### DIFF
--- a/rootegpythia6.sh
+++ b/rootegpythia6.sh
@@ -52,6 +52,12 @@ cmake "$SOURCEDIR" \
 cmake --build . ${JOBS:+-j$JOBS}
 cmake --install .
 
+# Fix rootmap: dictionary is named TPythia6 but library is EGPythia6
+# (upstream bug — contribute fix, keep this patch until merged)
+sed -i 's/libTPythia6\.so/libEGPythia6.so/' "$INSTALLROOT/lib/libTPythia6.rootmap"
+mv "$INSTALLROOT/lib/libTPythia6.rootmap" "$INSTALLROOT/lib/libEGPythia6.rootmap"
+mv "$INSTALLROOT/lib/libTPythia6_rdict.pcm" "$INSTALLROOT/lib/libEGPythia6_rdict.pcm"
+
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"


### PR DESCRIPTION
The upstream ROOT_GENERATE_DICTIONARY produces libTPythia6.rootmap referencing libTPythia6.so, but the actual library is libEGPythia6.so. ROOT auto-loading fails because libTPythia6.so does not exist.

Rename post-install until the upstream fix is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected library artifact handling during installation to ensure proper integration and prevent linking issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShipSoft/shipdist/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->