### PR TITLE
chore(fairship): drop unused HEPMC_DIR / HEPMC_INCLUDE_DIR flags

### DIFF
--- a/fairship.sh
+++ b/fairship.sh
@@ -114,8 +114,6 @@ cmake $SOURCEDIR                                                 \
       -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE                       \
       -DROOT_DIR=$ROOT_ROOT                                      \
       -DROOTEGPythia6_ROOT=$ROOTEGPYTHIA6_ROOT                   \
-      -DHEPMC_DIR=$HEPMC_ROOT                                    \
-      -DHEPMC_INCLUDE_DIR=$HEPMC_ROOT/include/HepMC              \
       -DEVTGEN_INCLUDE_DIR=$EVTGEN_ROOT/include                  \
       -DEVTGEN_LIBRARY_DIR=$EVTGEN_ROOT/lib                      \
       -DPYTHIA8_DIR=$PYTHIA_ROOT                                 \


### PR DESCRIPTION
## Summary

FairShip's CMake no longer reads `HEPMC_DIR` (its only consumer, `find_package2(PUBLIC HepMC)`, is removed in ShipSoft/FairShip#1214 — no source actually `#include`s HepMC) and the matching `HEPMC_INCLUDE_DIR` was dropped from `shipgen/CMakeLists.txt` in the same PR.

Passing these flags here only produces a "Manually-specified variables were not used" CMake warning on every FairShip build.

## Pairing

Pair with ShipSoft/FairShip#1214. Either order of merge is fine: while one side is in flight the warning shape changes (HEPMC_DIR ↔ HEPMC_INCLUDE_DIR) but no build breaks.

## Test plan

- [x] Verified no other place in `shipdist` consumes these variables (`grep -rn HEPMC` only hits `hepmc.sh` itself and `pythia.sh`'s `--with-hepmc2=` config, both unrelated).
- [ ] Next FairShip rebuild on cvmfs picks up the recipe change and the CMake warning disappears.