### PR TITLE
chore(fairship): update FairShip to 26.06

### DIFF
--- a/fairship.sh
+++ b/fairship.sh
@@ -1,6 +1,6 @@
 package: FairShip
 version: "%(tag_basename)s"
-tag: "26.05"
+tag: "26.06"
 source: https://github.com/ShipSoft/FairShip
 requires:
   - pythia

--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,6 @@
     {
       "description": "Packages tracking branches, not release tags",
       "matchPackageNames": [
-        "ShipSoft/FairShip",
         "luketpickering/ROOTEGPythia6",
         "hepmc/HepMC3"
       ],


### PR DESCRIPTION
## Summary
- Bump pinned FairShip tag from 26.05 → 26.06 (release published upstream as `b37e0067 refs/tags/26.06`).
- Drop `ShipSoft/FairShip` from the renovate disable list; the recipe has been following release tags since 26.05, so renovate can manage future bumps.