### PR TITLE
fix(rootegpythia6): keep TPythia6 PCM filename

### DIFF
--- a/rootegpythia6.sh
+++ b/rootegpythia6.sh
@@ -54,10 +54,15 @@ cmake --build . ${JOBS:+-j$JOBS}
 cmake --install .
 
 # Fix rootmap: dictionary is named TPythia6 but library is EGPythia6
-# (upstream bug — contribute fix, keep this patch until merged)
+# (upstream bug — contribute fix, keep this patch until merged).
+# ROOT scans *.rootmap by content, so the filename is cosmetic.
 sed -i 's/libTPythia6\.so/libEGPythia6.so/' "$INSTALLROOT/lib/libTPythia6.rootmap"
 mv "$INSTALLROOT/lib/libTPythia6.rootmap" "$INSTALLROOT/lib/libEGPythia6.rootmap"
-mv "$INSTALLROOT/lib/libTPythia6_rdict.pcm" "$INSTALLROOT/lib/libEGPythia6_rdict.pcm"
+
+# Do NOT rename libTPythia6_rdict.pcm: ROOT_GENERATE_DICTIONARY(TPythia6 ...)
+# bakes the literal filename libTPythia6_rdict.pcm into libEGPythia6.so's
+# dictionary registration. TCling::LoadPCM looks it up by the dictionary
+# name (TPythia6), not the library name (EGPythia6).
 
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"


### PR DESCRIPTION
ROOT_GENERATE_DICTIONARY(TPythia6 ...) bakes the literal filename libTPythia6_rdict.pcm into libEGPythia6.so's dictionary registration. TCling::LoadPCM resolves the PCM by the dictionary name (TPythia6), not the library name (EGPythia6), so renaming the file to libEGPythia6_rdict.pcm made ROOT fail at runtime with:

    Error in <TCling::LoadPCM>: ROOT PCM .../libTPythia6_rdict.pcm file does not exist

Drop the PCM rename and document why. The rootmap rename stays (ROOT scans rootmaps by content, so its filename is cosmetic). Mirrors the fix already applied in ship-conda-recipes.