### PR TITLE
Extend shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "schedule": ["every weekend"],
-  "prConcurrentLimit": 5,
+  "extends": ["local>ShipSoft/.github"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Switches the base config to `local>ShipSoft/.github` and removes the now-inherited `schedule`/`prConcurrentLimit`; the repo-specific custom managers and package rules are unchanged. Needs ShipSoft/.github#9 merged first.