### PR TITLE
docs: add CONTRIBUTING with prek hook setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to shipdist
+
+`shipdist` holds the [alidist](https://github.com/alisw/alidist) recipes used to
+build `FairShip` and its dependencies with `aliBuild`. As part of the SHiP
+Collaboration, we follow a set of standards to keep the recipes clean and
+consistent.
+
+## Development Workflow
+
+1. **Fork and Clone**: Create a fork of the repository and clone it locally.
+2. **Environment**: The linting toolchain is provisioned with [pixi](https://pixi.sh):
+   ```bash
+   pixi install
+   ```
+3. **Pre-commit Hooks**: We use [`prek`](https://github.com/j178/prek) (a drop-in `pre-commit` replacement) to enforce coding standards. The hook tools come from the pixi `lint` environment, so versions are tracked in `pixi.lock` and run identically everywhere. Install the hooks once:
+   ```bash
+   pixi run install-hooks
+   ```
+   Run all hooks manually at any time with `pixi run lint`. This runs the recipe
+   linters (`alidistlint`, `shellcheck`, `yamllint`) that also gate CI.
+4. **Branching**: Create a feature branch for your changes.
+5. **Commits**: We follow [Conventional Commits](https://www.conventionalcommits.org/) (validated by `commitizen`).
+6. **Submission**: Open a Pull Request against the `main` branch. Ensure the CI passes (recipe checks and linting).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # shipdist
 
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ShipSoft/shipdist/main.svg)](https://results.pre-commit.ci/latest/github/ShipSoft/shipdist/main)
-
 Recipes to build `FairShip` and it's dependencies using `aliBuild`
 
 ## General information


### PR DESCRIPTION
The repo had no CONTRIBUTING.md. Add one documenting the pixi lint environment and prek hooks (`pixi run install-hooks` / `pixi run lint`, running alidistlint/shellcheck/yamllint) plus conventional commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering setup, development workflows, code quality checks, commit conventions, and pull request expectations.
  * Removed the outdated pre-commit status badge from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->