### PR TITLE
fix(acts): bump shipdist-build pin to 946fd01

### DIFF
--- a/acts.sh
+++ b/acts.sh
@@ -1,6 +1,6 @@
 package: acts
 version: shipdist-build
-tag: 7bc78ecd82ff4469dd6f688392539928735a111a
+tag: 946fd01b881b01c37cfd40a6880517ea8356ab6a
 source: https://github.com/webbjm/acts.git
 requires:
   - ROOT


### PR DESCRIPTION
Mirrors the ACTS commit bump made in `ship-conda-recipes` (`recipes/acts-ship`).

Both build systems track the SHiP fork of ACTS (`webbjm/acts`, `shipdist-build` branch). The conda recipe was bumped to commit `946fd01` (HEAD of `shipdist-build` as of 2026-07-13); this updates the alibuild recipe's pin from the old `7bc78ec` to match.

Only the `tag:` field changes — `source:` already points at the same fork, and `version:` is the static string `shipdist-build`, so no version bump is needed.