### PR TITLE
chore: prepare 26.07

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Until May 2022 (inclusive) no changelog was kept. We might try to reconstruct it in future.
 
+## [26.07](https://github.com/ShipSoft/shipdist/tree/26.07)
+
+### Changed
+
+* FairShip: Update to 26.07
+
+### Fixed
+
+* ACTS: Bump shipdist-build pin to 946fd01
+
 ## [26.06](https://github.com/ShipSoft/shipdist/tree/26.06)
 
 ### Added


### PR DESCRIPTION
Add the `26.07` section to the changelog ahead of the release.

Covers the recipe/build changes since 26.06:

- **Changed:** FairShip updated to 26.07 (`574f56a3`)
- **Fixed:** ACTS shipdist-build pin bumped to `946fd01` (`94a5a196`)

Repo-infrastructure changes from this cycle (prek/pixi lint migration, CONTRIBUTING, README badge, Renovate preset) are intentionally omitted, consistent with the recipe/build-only scope of previous changelog sections.

Tagging `26.07` is a separate step once this merges.